### PR TITLE
Add Giscus comments section to blog posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@astrojs/react": "^3.6.0",
     "@astrojs/rss": "^4.0.5",
     "@astrojs/sitemap": "3.1.4",
+    "@giscus/react": "^3.1.0",
     "@iconify-json/clarity": "^1.1.13",
     "@iconify-json/formkit": "^1.1.8",
     "@iconify-json/lets-icons": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@astrojs/sitemap':
         specifier: 3.1.4
         version: 3.1.4
+      '@giscus/react':
+        specifier: ^3.1.0
+        version: 3.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@iconify-json/clarity':
         specifier: ^1.1.13
         version: 1.2.2
@@ -844,6 +847,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@giscus/react@3.1.0':
+    resolution: {integrity: sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==}
+    peerDependencies:
+      react: ^16 || ^17 || ^18 || ^19
+      react-dom: ^16 || ^17 || ^18 || ^19
+
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
 
@@ -1239,6 +1248,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@lit-labs/ssr-dom-shim@1.5.1':
+    resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
 
   '@marp-team/marp-core@4.1.0':
     resolution: {integrity: sha512-QJ79tGpr3itR4TVQ4Cbe9J0kLHg9sR5cNX19OWSHeVK9EjDzMA9iCwS+OCRMKBAvRHo0LGUJC3lm9wUBg3Ud6A==}
@@ -1860,6 +1875,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -3042,6 +3060,9 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
+  giscus@1.6.0:
+    resolution: {integrity: sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -3702,6 +3723,15 @@ packages:
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.2:
+    resolution: {integrity: sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==}
+
+  lit@3.3.2:
+    resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
 
   load-yaml-file@0.2.0:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
@@ -6273,6 +6303,12 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
+  '@giscus/react@3.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      giscus: 1.6.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@hapi/hoek@9.3.0': {}
 
   '@hapi/topo@5.1.0':
@@ -6704,6 +6740,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@lit-labs/ssr-dom-shim@1.5.1': {}
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
 
   '@marp-team/marp-core@4.1.0':
     dependencies:
@@ -7323,6 +7365,8 @@ snapshots:
       '@types/node': 22.15.30
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
 
@@ -8711,6 +8755,10 @@ snapshots:
 
   get-stream@6.0.1: {}
 
+  giscus@1.6.0:
+    dependencies:
+      lit: 3.3.2
+
   github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
@@ -9689,6 +9737,22 @@ snapshots:
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
+
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.2
+
+  lit-html@3.3.2:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.2:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.2
 
   load-yaml-file@0.2.0:
     dependencies:

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -29,6 +29,7 @@ import { Footer } from "../../features/Footer";
 import BlogPost from "./_components/BlogPost/index.astro";
 import SlidePost from "./_components/SlidePost.astro";
 import { Breadcrumb } from "../../ui/Breadcrumb";
+import { GiscusComments } from "../../ui/GiscusComments";
 import { SITE_URL } from "../../consts";
 ---
 
@@ -81,6 +82,10 @@ import { SITE_URL } from "../../consts";
           <BlogPost post={post} Content={Content} headings={headings} />
         )
       }
+
+      <section class="comments-section">
+        <GiscusComments client:visible />
+      </section>
     </main>
     <Footer client:only />
 
@@ -90,6 +95,12 @@ import { SITE_URL } from "../../consts";
         max-width: calc(70rem + 2rem);
         margin: 0 auto;
         padding: 96px 16px;
+      }
+
+      .comments-section {
+        width: 100%;
+        max-width: 40rem;
+        margin: 3rem auto 0;
       }
     </style>
   </body>

--- a/src/ui/GiscusComments/index.tsx
+++ b/src/ui/GiscusComments/index.tsx
@@ -1,0 +1,40 @@
+import Giscus from "@giscus/react";
+import { useEffect, useState } from "react";
+
+export const GiscusComments = () => {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const updateTheme = () => {
+      const isDark = document.documentElement.classList.contains("dark");
+      setTheme(isDark ? "dark" : "light");
+    };
+
+    updateTheme();
+
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Giscus
+      id="comments"
+      repo="yutteee/portfolio"
+      repoId="R_kgDONXFRsQ"
+      category="General"
+      categoryId="DIC_kwDONXFRsc4CpVEP"
+      mapping="pathname"
+      reactionsEnabled="1"
+      emitMetadata="0"
+      inputPosition="top"
+      theme={theme}
+      lang="ja"
+      loading="lazy"
+    />
+  );
+};


### PR DESCRIPTION
## 概要

ブログ記事ページにGiscusを使用したコメント機能を追加しました。GitHub Discussionsをバックエンドとして利用し、ユーザーがブログ記事に対してコメントできるようになります。

## 変更内容

- `src/ui/GiscusComments/index.tsx` を新規作成
  - GiscusコンポーネントをラップするReactコンポーネントを実装
  - ダークモード対応：ドキュメントのクラス属性を監視してテーマを動的に切り替え
  - MutationObserverを使用してリアルタイムでテーマ変更を検出

- `src/pages/posts/[slug].astro` を修正
  - GiscusCommentsコンポーネントをインポート
  - ブログ記事コンテンツの下にコメントセクションを追加
  - コメントセクション用のスタイルを追加（最大幅40rem、上部マージン3rem）
  - `client:visible` ディレクティブで遅延ロード対応

- `package.json` を修正
  - `@giscus/react` ^3.1.0 を依存関係に追加

## 確認事項

- [ ] ローカルで動作確認済み
- [ ] `pnpm run check` (Biome) がパスする
- [ ] `pnpm run test:unit` がパスする

https://claude.ai/code/session_01PPnrHG9fA7gzLm9xijch92