### PR TITLE
詳細系ページでの、ダークモード/ライトモードのちらつきを修正

### DIFF
--- a/src/components/ThemeScript.astro
+++ b/src/components/ThemeScript.astro
@@ -1,0 +1,12 @@
+<script is:inline>
+  // ブロッキングスクリプト: DOMが表示される前にテーマを適用
+  (function () {
+    const theme = localStorage.getItem("theme");
+    const isOsDark = window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches;
+    if (theme === "dark" || (theme === null && isOsDark)) {
+      document.documentElement.classList.add("dark");
+    }
+  })();
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ import { Footer } from "../features/Footer";
 import "../styles/global.css";
 import { SEO } from "astro-seo";
 import { SITE_URL } from "../consts";
+import ThemeScript from "../components/ThemeScript.astro";
 
 interface Props {
   title: string;
@@ -18,18 +19,7 @@ const { title, description, ogpType = "website" } = Astro.props;
 
 <html lang="ja">
   <head>
-    <script is:inline>
-      // ブロッキングスクリプト: DOMが表示される前にテーマを適用
-      (function () {
-        const theme = localStorage.getItem("theme");
-        const isOsDark = window.matchMedia(
-          "(prefers-color-scheme: dark)",
-        ).matches;
-        if (theme === "dark" || (theme === null && isOsDark)) {
-          document.documentElement.classList.add("dark");
-        }
-      })();
-    </script>
+    <ThemeScript />
     <link rel="icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width" />
     <SEO

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -30,11 +30,13 @@ import BlogPost from "./_components/BlogPost/index.astro";
 import SlidePost from "./_components/SlidePost.astro";
 import { Breadcrumb } from "../../ui/Breadcrumb";
 import { SITE_URL } from "../../consts";
+import ThemeScript from "../../components/ThemeScript.astro";
 ---
 
 <!doctype html>
 <html lang="ja">
   <head>
+    <ThemeScript />
     <link rel="icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width" />
     <SEO

--- a/src/pages/products/[slug].astro
+++ b/src/pages/products/[slug].astro
@@ -21,11 +21,13 @@ import { Header } from "../../features/Header";
 import { Footer } from "../../features/Footer";
 import ProductPost from "./_components/ProductPost/index.astro";
 import { Icon } from "astro-icon/components";
+import ThemeScript from "../../components/ThemeScript.astro";
 ---
 
 <!doctype html>
 <html lang="ja">
   <head>
+    <ThemeScript />
     <link rel="icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width" />
     <SEO


### PR DESCRIPTION
## 概要

<!-- このPRで何をしたか、なぜ必要かを簡潔に書いてください -->
ブログ詳細、プロダクト詳細では、BaseLayoutを使っていない。
BaseLayoutでダークモード適用の処理を書いているが、それが反映されていなかったため、一瞬ライトモードになってからダークモードになるちらつきが発生していたので、これを修正した。

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- scriptを切り出し
- BaseLayout置き換え
- 詳細ページにscript追加

## 確認事項

- [ ] ローカルで動作確認済み
- [ ] `pnpm run check` (Biome) がパスする
- [ ] `pnpm run test:unit` がパスする

## スクリーンショット（UI変更がある場合）

<!-- Before / After のスクリーンショットを貼ってください -->
