### PR TITLE
Remove external link attributes from ProductItem link test

### DIFF
--- a/src/ui/ProductItem/index.test.tsx
+++ b/src/ui/ProductItem/index.test.tsx
@@ -18,8 +18,6 @@ describe("ProductItem", () => {
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("href", baseProps.href);
     expect(link).toHaveAttribute("aria-label", baseProps.title);
-    expect(link).toHaveAttribute("target", "_blank");
-    expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it("画像のalt属性が正しい", () => {


### PR DESCRIPTION
## 概要

ProductItem コンポーネントのリンク要素から外部リンク属性（`target="_blank"` と `rel="noopener noreferrer"`）の検証を削除しました。これらの属性がコンポーネントの仕様から削除されたことに伴うテスト修正です。

## 変更内容

- ProductItem コンポーネントのテストから以下の2つのアサーションを削除：
  - `target="_blank"` 属性の検証
  - `rel="noopener noreferrer"` 属性の検証

## 確認事項

- [x] ローカルで動作確認済み
- [x] `pnpm run check` (Biome) がパスする
- [x] `pnpm run test:unit` がパスする

https://claude.ai/code/session_014Dd9SiRgL7HBUSjzyQPQ79