### PR TITLE
fleaky な interaction test を修正

### DIFF
--- a/vitest.storybook.config.ts
+++ b/vitest.storybook.config.ts
@@ -10,6 +10,19 @@ export default defineConfig({
   plugins: [
     storybookTest({ configDir: path.join(dirname, '.storybook') }),
   ],
+  // ブラウザモード初回起動時、走行中に Vite が新規依存を検出して再最適化＆再ロードが走ると、
+  // 最適化前後の React が二重ロードされ `useRef` 等が null になる。
+  // 起動前に prebundle を確定させることでコールドスタート時のレースを防ぐ。
+  optimizeDeps: {
+    include: [
+      'react',
+      'react-dom',
+      'react-dom/client',
+      'react/jsx-runtime',
+      'react/jsx-dev-runtime',
+      'react-icons/fi',
+    ],
+  },
   test: {
     include: ["src/**/*.test.tsx"],
     browser: {


### PR DESCRIPTION
## 概要

### 背景

`pnpm test:storybook`を実行すると、初回は以下のエラーを吐いて落ちる。

```
Vitest caught 8 unhandled errors during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeError: Cannot read properties of null (reading 'useRef')
...
```

2回目同様に`pnpm test:storybook`を実行すると、テストは成功する。

キャッシュを削除（`rm -rf node_modules/.vite node_modules/.cache`）してもう一度実行すると、同様にエラーが吐かれる。

### 原因

ブラウザモード（Playwright + Chromium）の Vitest における **Vite の依存事前バンドル（`optimizeDeps` / depsoptimizer）のコールドスタート問題** が原因。

#### エラーの意味

`TypeError: Cannot read properties of null (reading 'useRef')` は、React 内部の **current dispatcher が `null`** の状態でフックが呼ばれたときに出る。

React 本体は `useRef` などのフックを直接実装しているわけではなく、`ReactCurrentDispatcher.current` を介して現在のレンダラ（react-dom）から提供される実装に委譲している。レンダリングが開始される前、あるいは React モジュールが正しく初期化されていない状態でフックが呼ばれると、この dispatcher が `null` のままアクセスされて落ちる。

今回は `AnimationIcon` / `Header` どちらも普通の関数コンポーネントの中で `useRef` を呼んでおり、フックの使い方としては正しい。にも関わらず dispatcher が `null` になるのは、現実的には **React が 2 コピー読み込まれている**（"dual React" 状態。片方の React で `useRef` を呼んだが dispatcher は他方の React 側にしか登録されていない）ケースのみ。

#### なぜ React が二重ロードされるのか

Vite はブラウザに直接渡せない CJS 依存や巨大な ESM 依存を **prebundle**（esbuild で 1 ファイルに統合）してから配信する。事前バンドル結果は `node_modules/.cache/storybook/<hash>/sb-vitest/deps/` にキャッシュされる。

ブラウザモードのテストは prebundle 完了後にモジュールを取りに行くのが理想だが、キャッシュが無いコールドスタート時には次のことが起きる：

1. ストーリーファイルや `react-icons/fi`（多 named export の重いバレル）等の解析中に、Vite が走行中に「これは事前バンドル対象だ」と新規依存を検出
2. Vite はクライアントの再ロード（"new deps discovered"）を要求するが、ブラウザモードのテストは既にモジュールの取り込みを始めている
3. **再最適化前の React を取り込んだモジュール** と **再最適化後の React を取り込んだモジュール** が混在し、別オブジェクトの React が 2 つ生まれる
4. レンダリング時、dispatcher が登録されていない側の React で `useRef` が呼ばれ → `null.useRef` でクラッシュ

2 回目以降は prebundle 結果が `sb-vitest/deps/` に残っているためコールドスタート時の再ロードが発生せず、全テストが通る。これが「初回だけ失敗、2 回目以降は成功」の正体。

#### キャッシュ場所に関する注意

prebundle 結果は Vite デフォルトの `node_modules/.vite/` ではなく、**`node_modules/.cache/storybook/<hash>/sb-vitest/deps/`** に置かれる。これは `@storybook/addon-vitest` プラグインが Vite の `cacheDir` をこのパスに上書きしているため。

そのため、再現確認の際は `rm -rf node_modules/.vite` だけでは不十分で、`rm -rf node_modules/.cache` まで消す必要がある。

## 変更内容

## 確認事項

- [ ] ローカルで動作確認済み
- [ ] `pnpm run check` (Biome) がパスする
- [ ] `pnpm run test:unit` がパスする

## スクリーンショット（UI変更がある場合）

