### PR TITLE
Fix Storybook addon-viewport import path

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,7 +11,7 @@ const config: StorybookConfig = {
     "@storybook/addon-a11y",
     "@storybook/addon-vitest",
     'storybook-addon-test-codegen',
-    'storybook/addon-viewport',
+    '@storybook/addon-viewport',
   ],
   "framework": {
     "name": "@storybook/react-vite",


### PR DESCRIPTION
## 概要

Storybook の addon-viewport の import パスを修正しました。`'storybook/addon-viewport'` から `'@storybook/addon-viewport'` に変更し、正しいパッケージ名を使用するようにしました。

## 変更内容

- `.storybook/main.ts` の addon 設定で `'storybook/addon-viewport'` を `'@storybook/addon-viewport'` に修正

## 確認事項

- [ ] ローカルで動作確認済み
- [ ] `pnpm run check` (Biome) がパスする
- [ ] `pnpm run test:unit` がパスする

https://claude.ai/code/session_01GejdkbQzDYm3GCUysqD3U9