### PR TITLE
トップのプロダクトの並び順を修正

### DIFF
--- a/src/pages/_components/TopProducts.astro
+++ b/src/pages/_components/TopProducts.astro
@@ -3,7 +3,9 @@ import { ProductItem } from "../../ui/ProductItem";
 import { getCollection } from "astro:content";
 import { LinkButton } from "../../ui/LinkButton";
 
-const productsCollection = await getCollection("products");
+const productsCollection = (await getCollection("products")).sort((a, b) =>
+  b.data.period.localeCompare(a.data.period),
+);
 ---
 
 <section class="container">


### PR DESCRIPTION
## 概要

<!-- このPRで何をしたか、なぜ必要かを簡潔に書いてください -->

トップページのプロダクトの並び順にソートを追加した。
プロダクトページと順序が違ったため。

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

-

## 確認事項

- [ ] ローカルで動作確認済み
- [ ] `pnpm run check` (Biome) がパスする
- [ ] `pnpm run test:unit` がパスする

## スクリーンショット（UI変更がある場合）

<!-- Before / After のスクリーンショットを貼ってください -->
