### PR TITLE
fix(BlogPost): center external link icon vertically with title

### DIFF
--- a/src/ui/BlogPost/index.module.css
+++ b/src/ui/BlogPost/index.module.css
@@ -43,7 +43,7 @@
 .title {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   font-size: 1.125rem;
   font-weight: 700;
 }

--- a/src/ui/BlogPost/index.module.css
+++ b/src/ui/BlogPost/index.module.css
@@ -41,6 +41,9 @@
   font-weight: bold;
 }
 .title {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   font-size: 1.125rem;
   font-weight: 700;
 }

--- a/src/ui/BlogPost/index.tsx
+++ b/src/ui/BlogPost/index.tsx
@@ -45,8 +45,8 @@ export const BlogPost: React.FC<BlogPostProps> = ({
             {marp && <span className={styles.slideBadge}>スライド</span>}
           </div>
           <div className={styles.title}>
-            {title}
-            {isExternal && <FiExternalLink style={{ marginLeft: 4 }} />}
+            <span>{title}</span>
+            {isExternal && <FiExternalLink aria-hidden />}
           </div>
         </div>
       </a>


### PR DESCRIPTION
タイトルとアイコンの縦位置を揃えるため、.title を flex (align-items: center)
に変更。インライン SVG が line-height によりベースラインに沿って
ずれていた問題を修正。