### PR TITLE
Fix title line-height in TopArticles and TopProducts

### DIFF
--- a/src/pages/_components/TopArticles.astro
+++ b/src/pages/_components/TopArticles.astro
@@ -45,6 +45,7 @@ const allPosts = await getAllPosts();
       .title {
         font-size: 4rem;
         font-weight: 900;
+        line-height: 1;
 
         @media screen and (max-width: 1000px) {
           font-size: 2rem;

--- a/src/pages/_components/TopProducts.astro
+++ b/src/pages/_components/TopProducts.astro
@@ -47,6 +47,7 @@ const productsCollection = (await getCollection("products")).sort((a, b) =>
       .title {
         font-size: 4rem;
         font-weight: 900;
+        line-height: 1;
 
         @media screen and (max-width: 1000px) {
           font-size: 2rem;


### PR DESCRIPTION
## 概要

TopArticles と TopProducts コンポーネントのタイトル要素に `line-height: 1` を追加し、タイトルの行間を調整しました。大きなフォントサイズ（4rem）でのタイトル表示を改善します。

## 変更内容

- `src/pages/_components/TopArticles.astro`: `.title` クラスに `line-height: 1` を追加
- `src/pages/_components/TopProducts.astro`: `.title` クラスに `line-height: 1` を追加

## 確認事項

- [ ] ローカルで動作確認済み
- [ ] `pnpm run check` (Biome) がパスする
- [ ] `pnpm run test:unit` がパスする

## スクリーンショット（UI変更がある場合）

<!-- Before / After のスクリーンショットを貼ってください -->

https://claude.ai/code/session_01CJdCcpu5NEhQHbWaGZa4wE