### PR TITLE
fix: 詳細ページのサムネイル画像にアスペクト比を指定

### DIFF
--- a/src/pages/posts/_components/BlogPost/index.astro
+++ b/src/pages/posts/_components/BlogPost/index.astro
@@ -112,6 +112,8 @@ const { post, Content, headings } = Astro.props;
       .image {
         width: 100%;
         height: auto;
+        aspect-ratio: 720 / 378;
+        object-fit: cover;
         border: 8px solid var(--color-white);
         border-radius: 0.5rem;
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);

--- a/src/pages/products/_components/ProductPost/index.astro
+++ b/src/pages/products/_components/ProductPost/index.astro
@@ -117,6 +117,8 @@ const { product, Content } = Astro.props;
     .image {
       width: 100%;
       height: auto;
+      aspect-ratio: 720 / 450;
+      object-fit: cover;
       border: 8px solid var(--color-white);
       border-radius: 0.5rem;
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
縦長画像をアップロードした際に表示が縦に伸びてしまうため、
width/height 属性に合わせた aspect-ratio と object-fit: cover を
指定して表示形状を固定する。