### PR TITLE
fix: pnpm のバージョン管理を packageManager に統一

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,5 @@
     "4321": { "label": "Astro Dev Server", "onAutoForward": "notify" },
     "6006": { "label": "Storybook", "onAutoForward": "notify" }
   },
-  "postCreateCommand": "npm install -g pnpm@10.27 && pnpm install && pnpm exec playwright install --with-deps chromium"
+  "postCreateCommand": "corepack enable && corepack prepare --activate && pnpm install && pnpm exec playwright install --with-deps chromium"
 }

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## 概要

devcontainer と GitHub Actions の pnpm バージョン指定を `package.json` の `packageManager` フィールドに集約。corepack 経由で常に同じバージョン (pnpm@10.29.3) が使われるようにし、環境間の乖離による lockfile 互換性問題を防ぐ。

Closes: `issues/pnpm-version-inconsistency.md`

## 参考

`pnpm/action-setup@v4` は `version` 入力が省略されたとき、`package.json` の `packageManager` フィールドを参照する仕様のため、既存の構成で pnpm@10.29.3 が自動的に選択される。

> [!NOTE]
> 公式リポジトリ [pnpm/action-setup](https://github.com/pnpm/action-setup) の README、`Inputs` セクションの `version` の項目に以下の記述がある:
>
> > **Optional** when there is a [`packageManager` field in the `package.json`](https://nodejs.org/api/corepack.html). otherwise, this field is **required**
