### PR TITLE
Add BIZ UDPGothic font with Google Fonts integration

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,6 +22,12 @@ const { title, description, ogpType = "website" } = Astro.props;
   <head>
     <AnimationScript />
     <ThemeScript />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=BIZ+UDPGothic:wght@400;700&display=swap"
+    />
     <link rel="icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width" />
     <SEO

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,7 +17,8 @@
 html {
   background-color: var(--color-background);
   color: var(--color-text);
-  font-family: "Helvetica Neue",
+  font-family: "BIZ UDPGothic",
+    "Helvetica Neue",
     Arial,
     "Hiragino Kaku Gothic ProN",
     "Hiragino Sans",


### PR DESCRIPTION
## 概要

Google Fonts から BIZ UDPGothic フォントを導入し、サイトのデフォルトフォントを変更。

多くの人にとって読みやすいUDフォントを導入するため。

## 変更内容

- `src/layouts/BaseLayout.astro`: Google Fonts へのプリコネクトリンクと BIZ UDPGothic フォントの CSS を追加
- `src/styles/global.css`: グローバルフォントファミリーを "BIZ UDPGothic" に変更（フォールバックは既存のまま）

## 確認事項

- [ ] ローカルで動作確認済み
- [ ] `pnpm run check` (Biome) がパスする
- [ ] `pnpm run test:unit` がパスする

https://claude.ai/code/session_01DK2n4ddiZMUfLt5y6of8Kp