### PR TITLE
fix: 詳細ページにもグローバルなフォント設定を適用する

### DIFF
--- a/src/components/CommonHead.astro
+++ b/src/components/CommonHead.astro
@@ -1,0 +1,13 @@
+---
+import ThemeScript from "./ThemeScript.astro";
+---
+
+<ThemeScript />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=BIZ+UDPGothic:wght@400;700&display=swap"
+/>
+<link rel="icon" href="/favicon.svg" />
+<meta name="viewport" content="width=device-width" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,7 +7,7 @@ import "../styles/global.css";
 import { SEO } from "astro-seo";
 import { SITE_URL } from "../consts";
 import AnimationScript from "../components/AnimationScript.astro";
-import ThemeScript from "../components/ThemeScript.astro";
+import CommonHead from "../components/CommonHead.astro";
 
 interface Props {
   title: string;
@@ -21,15 +21,7 @@ const { title, description, ogpType = "website" } = Astro.props;
 <html lang="ja">
   <head>
     <AnimationScript />
-    <ThemeScript />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=BIZ+UDPGothic:wght@400;700&display=swap"
-    />
-    <link rel="icon" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width" />
+    <CommonHead />
     <SEO
       charset="UTF-8"
       title={`${title} | yutteee-portfolio`}

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -30,15 +30,13 @@ import BlogPost from "./_components/BlogPost/index.astro";
 import SlidePost from "./_components/SlidePost.astro";
 import { Breadcrumb } from "../../ui/Breadcrumb";
 import { SITE_URL } from "../../consts";
-import ThemeScript from "../../components/ThemeScript.astro";
+import CommonHead from "../../components/CommonHead.astro";
 ---
 
 <!doctype html>
 <html lang="ja">
   <head>
-    <ThemeScript />
-    <link rel="icon" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width" />
+    <CommonHead />
     <SEO
       charset="UTF-8"
       title={`${post.data.title} | yutteee-portfolio`}

--- a/src/pages/products/[slug].astro
+++ b/src/pages/products/[slug].astro
@@ -21,15 +21,13 @@ import { Header } from "../../features/Header";
 import { Footer } from "../../features/Footer";
 import ProductPost from "./_components/ProductPost/index.astro";
 import { Icon } from "astro-icon/components";
-import ThemeScript from "../../components/ThemeScript.astro";
+import CommonHead from "../../components/CommonHead.astro";
 ---
 
 <!doctype html>
 <html lang="ja">
   <head>
-    <ThemeScript />
-    <link rel="icon" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width" />
+    <CommonHead />
     <SEO
       charset="UTF-8"
       title={`${product.data.title} | yutteee-portfolio`}


### PR DESCRIPTION
BaseLayout を使わない詳細ページ (posts/[slug], products/[slug]) では
BIZ UDPGothic を読み込む <link> が出力されず、Web フォントが適用されない
状態だった。

共通の <head> 要素 (ThemeScript / フォント link / favicon / viewport) を
CommonHead.astro として切り出し、BaseLayout と詳細ページの双方から
利用するよう変更した。