### PR TITLE
fix(BlogPost): タイトル末尾文字の隣に外部リンクアイコンを配置

### DIFF
--- a/src/ui/BlogPost/index.module.css
+++ b/src/ui/BlogPost/index.module.css
@@ -44,7 +44,7 @@
   font-size: 1.125rem;
   font-weight: 700;
 }
-.title svg {
+.icon {
   display: inline;
   vertical-align: -0.125em;
   margin-left: 2px;

--- a/src/ui/BlogPost/index.module.css
+++ b/src/ui/BlogPost/index.module.css
@@ -41,11 +41,13 @@
   font-weight: bold;
 }
 .title {
-  display: flex;
-  align-items: center;
-  gap: 2px;
   font-size: 1.125rem;
   font-weight: 700;
+}
+.title svg {
+  display: inline;
+  vertical-align: -0.125em;
+  margin-left: 2px;
 }
 .link:hover .image {
   transform: scale(1.1);

--- a/src/ui/BlogPost/index.tsx
+++ b/src/ui/BlogPost/index.tsx
@@ -46,7 +46,9 @@ export const BlogPost: React.FC<BlogPostProps> = ({
           </div>
           <div className={styles.title}>
             <span>{title}</span>
-            {isExternal && <FiExternalLink aria-hidden />}
+            {isExternal && (
+              <FiExternalLink aria-hidden className={styles.icon} />
+            )}
           </div>
         </div>
       </a>


### PR DESCRIPTION
タイトルが複数行に折り返したときに外部リンクアイコンがブロック全体の
垂直中央に配置されてしまう問題を解消し、最後の文字の直後にインライン
で並ぶようにする。