### PR TITLE
fix(Breadcrumb): 長いタイトルを祖先リンクと同じ行からインライン折り返しさせる

### DIFF
--- a/src/ui/Breadcrumb/index.module.css
+++ b/src/ui/Breadcrumb/index.module.css
@@ -1,8 +1,4 @@
 .breadcrumbs {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
   padding: 0.5rem 1rem;
   background-color: var(--color-white);
   height: fit-content;
@@ -20,12 +16,21 @@
 }
 
 .item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  display: inline;
+}
+
+/* 祖先アイテムはラベルとシェブロンを分けず一塊として扱う */
+.item:not(:last-child) {
+  white-space: nowrap;
+  margin-right: 0.5rem;
 }
 
 .item a {
   color: var(--color-link);
   text-decoration: underline;
+}
+
+.item svg {
+  vertical-align: middle;
+  margin-left: 0.5rem;
 }

--- a/src/ui/Breadcrumb/index.module.css
+++ b/src/ui/Breadcrumb/index.module.css
@@ -19,9 +19,7 @@
   display: inline;
 }
 
-/* 祖先アイテムはラベルとシェブロンを分けず一塊として扱う */
 .item:not(:last-child) {
-  white-space: nowrap;
   margin-right: 0.5rem;
 }
 

--- a/src/ui/Breadcrumb/index.stories.tsx
+++ b/src/ui/Breadcrumb/index.stories.tsx
@@ -36,3 +36,22 @@ export const ThreeLevels: Story = {
     currentLabel: "記事タイトル",
   },
 };
+
+export const LongCurrentLabel: Story = {
+  name: "現在ラベルが長い場合（テキストがインラインで折り返される）",
+  args: {
+    items: [
+      { label: "トップ", href: "/" },
+      { label: "記事", href: "/posts" },
+    ],
+    currentLabel:
+      "Claude Code 主軸の開発に合わせて Dev Container をカスタマイズする",
+  },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ maxWidth: "32rem" }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+};


### PR DESCRIPTION
flex レイアウトでは現在ページの li 全体が改行され、祖先リンク行と
タイトル行が分離していた。インラインレイアウトに変更し、祖先アイテム
内は nowrap でラベルとシェブロンを連結しつつ、現在ラベルは自然な
インライン折り返しが効くようにする。