### PR TITLE
Enforce CSS custom properties with stylelint

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,32 @@
+{
+  "plugins": ["stylelint-declaration-strict-value"],
+  "rules": {
+    "scale-unlimited/declaration-strict-value": [
+      [
+        "color",
+        "background-color",
+        "border-color",
+        "font-size",
+        "border-radius",
+        "gap",
+        "box-shadow"
+      ],
+      {
+        "ignoreValues": [
+          "inherit",
+          "initial",
+          "unset",
+          "currentColor",
+          "transparent",
+          "none",
+          "0",
+          "50%",
+          "100%"
+        ],
+        "disableFix": true,
+        "message": "Use a CSS custom property (var(--...)) instead of a hardcoded value for \"${property}\""
+      }
+    ]
+  },
+  "ignoreFiles": ["src/marp-themes/**", "dist/**", "node_modules/**"]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "node scripts/copy-images.js && astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "check": "biome check ./src",
+    "check": "biome check ./src && stylelint 'src/**/*.css'",
+    "check:css": "stylelint 'src/**/*.css'",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "vitest --config vitest.unit.config.ts && vitest --config vitest.storybook.config.ts",
@@ -67,6 +68,8 @@
     "plop": "^4.0.1",
     "storybook": "^9.0.0",
     "storybook-addon-test-codegen": "^2.0.1",
+    "stylelint": "^17.12.0",
+    "stylelint-declaration-strict-value": "^1.11.1",
     "vitest": "^3.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,12 @@ importers:
       storybook-addon-test-codegen:
         specifier: ^2.0.1
         version: 2.0.1(storybook@9.0.6(@testing-library/dom@10.4.0))
+      stylelint:
+        specifier: ^17.12.0
+        version: 17.12.0(typescript@5.8.3)
+      stylelint-declaration-strict-value:
+        specifier: ^1.11.1
+        version: 1.11.1(stylelint@17.12.0(typescript@5.8.3))
       vitest:
         specifier: ^3.1.4
         version: 3.2.2(@types/debug@4.1.12)(@types/node@22.15.30)(@vitest/browser@3.2.2)(jsdom@25.0.1)(yaml@2.8.0)
@@ -483,6 +489,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@cacheable/memory@2.0.9':
+    resolution: {integrity: sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==}
+
+  '@cacheable/utils@2.4.1':
+    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
+
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
     engines: {node: '>=18'}
@@ -493,6 +505,13 @@ packages:
     peerDependencies:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
   '@csstools/css-color-parser@3.0.10':
     resolution: {integrity: sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==}
@@ -507,9 +526,34 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4':
+    resolution: {integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/media-query-list-parser@5.0.0':
+    resolution: {integrity: sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
   '@csstools/postcss-is-pseudo-class@5.0.3':
     resolution: {integrity: sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==}
@@ -523,11 +567,23 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.0.0
 
+  '@csstools/selector-resolve-nested@4.0.0':
+    resolution: {integrity: sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
+
   '@csstools/selector-specificity@5.0.0':
     resolution: {integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==}
     engines: {node: '>=18'}
     peerDependencies:
       postcss-selector-parser: ^7.0.0
+
+  '@csstools/selector-specificity@6.0.0':
+    resolution: {integrity: sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -1240,6 +1296,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@marp-team/marp-core@4.1.0':
     resolution: {integrity: sha512-QJ79tGpr3itR4TVQ4Cbe9J0kLHg9sR5cNX19OWSHeVK9EjDzMA9iCwS+OCRMKBAvRHo0LGUJC3lm9wUBg3Ud6A==}
     engines: {node: '>=18'}
@@ -1528,6 +1593,10 @@ packages:
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
@@ -2027,6 +2096,10 @@ packages:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -2091,6 +2164,10 @@ packages:
 
   ast-v8-to-istanbul@0.3.3:
     resolution: {integrity: sha512-MuXMrSLVVoA6sYN/6Hke18vMzrT4TZNbZIj/hvh0fnYFpO+/kFXcLIaiPwXXWaQUPg4yJD8fj+lfJ7/1EBconw==}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -2210,6 +2287,9 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cacheable@2.3.5:
+    resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
 
   caching-transform@4.0.0:
     resolution: {integrity: sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==}
@@ -2399,6 +2479,9 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -2456,6 +2539,15 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2475,6 +2567,10 @@ packages:
     resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
     engines: {node: '>=4'}
 
+  css-functions-list@3.3.3:
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
+    engines: {node: '>=12'}
+
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
 
@@ -2487,6 +2583,10 @@ packages:
 
   css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-what@6.1.0:
@@ -2525,6 +2625,15 @@ packages:
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -2715,6 +2824,10 @@ packages:
     resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
     engines: {node: '>=0.12'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
@@ -2883,6 +2996,10 @@ packages:
     resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
     hasBin: true
 
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2902,6 +3019,9 @@ packages:
 
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+
+  file-entry-cache@11.1.3:
+    resolution: {integrity: sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2949,6 +3069,12 @@ packages:
   flagged-respawn@2.0.0:
     resolution: {integrity: sha512-Gq/a6YCi8zexmGHMuJwahTGzXlAZAOsbCVKduWXC6TlLCjjFRlExMJc4GC2NYPYZ0r/brw9P7CpRgQmlPVeOoA==}
     engines: {node: '>= 10.13.0'}
+
+  flat-cache@6.1.22:
+    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
@@ -3022,6 +3148,10 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -3065,6 +3195,10 @@ packages:
     resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
     engines: {node: '>=0.10.0'}
 
+  global-modules@2.0.0:
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    engines: {node: '>=6'}
+
   global-prefix@0.1.5:
     resolution: {integrity: sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==}
     engines: {node: '>=0.10.0'}
@@ -3072,6 +3206,10 @@ packages:
   global-prefix@1.0.2:
     resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
+
+  global-prefix@3.0.0:
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    engines: {node: '>=6'}
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3084,6 +3222,13 @@ packages:
   globby@13.2.2:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  globby@16.2.0:
+    resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
+    engines: {node: '>=20'}
+
+  globjoin@0.1.4:
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3112,6 +3257,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -3123,6 +3272,10 @@ packages:
   hasha@5.2.2:
     resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
     engines: {node: '>=8'}
+
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -3179,6 +3332,12 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -3188,6 +3347,10 @@ packages:
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  html-tags@5.1.0:
+    resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
+    engines: {node: '>=20.10'}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -3228,6 +3391,14 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
   import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
@@ -3235,6 +3406,9 @@ packages:
 
   import-meta-resolve@4.1.0:
     resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -3671,6 +3845,9 @@ packages:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
 
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -3732,6 +3909,9 @@ packages:
 
   lodash.kebabcase@4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -3817,6 +3997,9 @@ packages:
   mathjax-full@3.2.2:
     resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
 
+  mathml-tag-names@4.0.0:
+    resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
+
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
 
@@ -3874,8 +4057,15 @@ packages:
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  meow@14.1.0:
+    resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
+    engines: {node: '>=20'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -4081,6 +4271,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -4235,6 +4430,10 @@ packages:
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
   parse-css-color@0.2.1:
     resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
@@ -4371,12 +4570,26 @@ packages:
     peerDependencies:
       postcss: ^8.4
 
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
   postcss-selector-parser@7.1.0:
     resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
     engines: {node: '>=4'}
 
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.4:
     resolution: {integrity: sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==}
@@ -4433,6 +4646,10 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
+    engines: {node: '>=20'}
 
   quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
@@ -4584,6 +4801,10 @@ packages:
   resolve-dir@1.0.1:
     resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
     engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -4755,6 +4976,10 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
@@ -4841,6 +5066,10 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
   string.prototype.codepointat@0.2.1:
     resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
 
@@ -4856,6 +5085,10 @@ packages:
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom-string@1.0.0:
@@ -4895,6 +5128,21 @@ packages:
   style-to-object@1.0.8:
     resolution: {integrity: sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==}
 
+  stylelint-declaration-strict-value@1.11.1:
+    resolution: {integrity: sha512-DYihiMuKGk9AeCYp+c3PMy6Z+Qu6yb6wRLeXQJZVMdXV+QOqs7P+Xj6jt8RVTgFJfII+cEQaFI5uWu08WwlkOA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: '>=16 <=17'
+
+  stylelint@17.12.0:
+    resolution: {integrity: sha512-KIlzWXMHUvgfPUR0R7TK3H80yCIi0uoivUwf+6Az4yrHJD1Q3c1qIkh/H5Z0i/K3QXgtq/UMEkWyBUSUwnpnOg==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -4907,9 +5155,16 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-hyperlinks@4.4.0:
+    resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
+    engines: {node: '>=20'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svg-tags@1.0.0:
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
   svgo@3.3.2:
     resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
@@ -4918,6 +5173,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
@@ -5097,6 +5356,10 @@ packages:
 
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
 
   unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
@@ -5518,6 +5781,10 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   ws@8.18.2:
     resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
@@ -6062,12 +6329,29 @@ snapshots:
   '@biomejs/cli-win32-x64@1.8.3':
     optional: true
 
+  '@cacheable/memory@2.0.9':
+    dependencies:
+      '@cacheable/utils': 2.4.1
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.4.1':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@csstools/color-helpers@5.0.2': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
   '@csstools/css-color-parser@3.0.10(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -6080,7 +6364,22 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@csstools/media-query-list-parser@5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
   '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.4)':
     dependencies:
@@ -6092,9 +6391,17 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.0
 
+  '@csstools/selector-resolve-nested@4.0.0(postcss-selector-parser@7.1.1)':
+    dependencies:
+      postcss-selector-parser: 7.1.1
+
   '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.0)':
     dependencies:
       postcss-selector-parser: 7.1.0
+
+  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.1)':
+    dependencies:
+      postcss-selector-parser: 7.1.1
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:
@@ -6705,6 +7012,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
+
   '@marp-team/marp-core@4.1.0':
     dependencies:
       '@marp-team/marpit': 3.1.3
@@ -6956,6 +7271,8 @@ snapshots:
   '@sideway/pinpoint@2.0.0': {}
 
   '@sinclair/typebox@0.27.8': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@sinonjs/commons@3.0.1':
     dependencies:
@@ -7550,6 +7867,8 @@ snapshots:
 
   ansi-regex@6.1.0: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
@@ -7604,6 +7923,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       estree-walker: 3.0.3
       js-tokens: 9.0.1
+
+  astral-regex@2.0.0: {}
 
   astring@1.9.0: {}
 
@@ -7842,6 +8163,14 @@ snapshots:
 
   cac@6.7.14: {}
 
+  cacheable@2.3.5:
+    dependencies:
+      '@cacheable/memory': 2.0.9
+      '@cacheable/utils': 2.4.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.10.1
+
   caching-transform@4.0.0:
     dependencies:
       hasha: 5.2.2
@@ -8043,6 +8372,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  colord@2.9.3: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -8083,6 +8414,15 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cosmiconfig@9.0.1(typescript@5.8.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.8.3
+
   create-jest@29.7.0(@types/node@22.15.30):
     dependencies:
       '@jest/types': 29.6.3
@@ -8110,6 +8450,8 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
+  css-functions-list@3.3.3: {}
+
   css-select@5.1.0:
     dependencies:
       boolbase: 1.0.0
@@ -8132,6 +8474,11 @@ snapshots:
   css-tree@2.3.1:
     dependencies:
       mdn-data: 2.0.30
+      source-map-js: 1.2.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
       source-map-js: 1.2.1
 
   css-what@6.1.0: {}
@@ -8164,6 +8511,10 @@ snapshots:
       whatwg-url: 14.2.0
 
   debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -8328,6 +8679,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.0: {}
+
+  env-paths@2.2.1: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -8556,6 +8909,8 @@ snapshots:
     dependencies:
       strnum: 2.1.1
 
+  fastest-levenshtein@1.0.16: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -8573,6 +8928,10 @@ snapshots:
       picomatch: 4.0.2
 
   fflate@0.7.4: {}
+
+  file-entry-cache@11.1.3:
+    dependencies:
+      flat-cache: 6.1.22
 
   fill-range@7.1.1:
     dependencies:
@@ -8633,6 +8992,14 @@ snapshots:
 
   flagged-respawn@2.0.0: {}
 
+  flat-cache@6.1.22:
+    dependencies:
+      cacheable: 2.3.5
+      flatted: 3.4.2
+      hookified: 1.15.1
+
+  flatted@3.4.2: {}
+
   flattie@1.1.1: {}
 
   follow-redirects@1.15.9: {}
@@ -8684,6 +9051,8 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -8746,6 +9115,10 @@ snapshots:
       is-windows: 1.0.2
       resolve-dir: 1.0.1
 
+  global-modules@2.0.0:
+    dependencies:
+      global-prefix: 3.0.0
+
   global-prefix@0.1.5:
     dependencies:
       homedir-polyfill: 1.0.3
@@ -8761,6 +9134,12 @@ snapshots:
       is-windows: 1.0.2
       which: 1.3.1
 
+  global-prefix@3.0.0:
+    dependencies:
+      ini: 1.3.8
+      kind-of: 6.0.3
+      which: 1.3.1
+
   globals@11.12.0: {}
 
   globals@15.15.0: {}
@@ -8772,6 +9151,17 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 4.0.0
+
+  globby@16.2.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
+
+  globjoin@0.1.4: {}
 
   gopd@1.2.0: {}
 
@@ -8799,6 +9189,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-flag@5.0.1: {}
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -8809,6 +9201,10 @@ snapshots:
     dependencies:
       is-stream: 2.0.1
       type-fest: 0.8.1
+
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
 
   hasown@2.0.2:
     dependencies:
@@ -8955,6 +9351,10 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
+  hookified@1.15.1: {}
+
+  hookified@2.2.0: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -8962,6 +9362,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-escaper@3.0.3: {}
+
+  html-tags@5.1.0: {}
 
   html-void-elements@3.0.0: {}
 
@@ -9011,12 +9413,21 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
   import-local@3.2.0:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
   import-meta-resolve@4.1.0: {}
+
+  import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -9658,6 +10069,10 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
@@ -9721,6 +10136,8 @@ snapshots:
   lodash.get@4.4.2: {}
 
   lodash.kebabcase@4.1.1: {}
+
+  lodash.truncate@4.4.2: {}
 
   lodash@4.17.21: {}
 
@@ -9807,6 +10224,8 @@ snapshots:
       mhchemparser: 4.2.1
       mj-context-menu: 0.6.1
       speech-rule-engine: 4.1.2
+
+  mathml-tag-names@4.0.0: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -9981,7 +10400,11 @@ snapshots:
 
   mdn-data@2.0.30: {}
 
+  mdn-data@2.27.1: {}
+
   mdurl@2.0.0: {}
+
+  meow@14.1.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -10318,6 +10741,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.12: {}
+
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
@@ -10528,6 +10953,10 @@ snapshots:
       dot-case: 3.0.4
       tslib: 2.8.1
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
   parse-css-color@0.2.1:
     dependencies:
       color-name: 1.1.4
@@ -10679,12 +11108,27 @@ snapshots:
       postcss: 8.5.4
       postcss-selector-parser: 7.1.0
 
+  postcss-safe-parser@7.0.1(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
   postcss-selector-parser@7.1.0:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.4:
     dependencies:
@@ -10740,6 +11184,10 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  qified@0.10.1:
+    dependencies:
+      hookified: 2.2.0
 
   quansync@0.2.10: {}
 
@@ -10966,6 +11414,8 @@ snapshots:
     dependencies:
       expand-tilde: 2.0.2
       global-modules: 1.0.0
+
+  resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
 
@@ -11233,6 +11683,12 @@ snapshots:
 
   slash@5.1.0: {}
 
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -11340,6 +11796,11 @@ snapshots:
       get-east-asian-width: 1.3.0
       strip-ansi: 7.1.0
 
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string.prototype.codepointat@0.2.1: {}
 
   string_decoder@1.3.0:
@@ -11358,6 +11819,10 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom-string@1.0.0: {}
 
@@ -11387,6 +11852,53 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
+  stylelint-declaration-strict-value@1.11.1(stylelint@17.12.0(typescript@5.8.3)):
+    dependencies:
+      stylelint: 17.12.0(typescript@5.8.3)
+
+  stylelint@17.12.0(typescript@5.8.3):
+    dependencies:
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.1)
+      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
+      colord: 2.9.3
+      cosmiconfig: 9.0.1(typescript@5.8.3)
+      css-functions-list: 3.3.3
+      css-tree: 3.2.1
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      fastest-levenshtein: 1.0.16
+      file-entry-cache: 11.1.3
+      global-modules: 2.0.0
+      globby: 16.2.0
+      globjoin: 0.1.4
+      html-tags: 5.1.0
+      ignore: 7.0.5
+      import-meta-resolve: 4.2.0
+      mathml-tag-names: 4.0.0
+      meow: 14.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-safe-parser: 7.0.1(postcss@8.5.15)
+      postcss-selector-parser: 7.1.1
+      postcss-value-parser: 4.2.0
+      string-width: 8.2.1
+      supports-hyperlinks: 4.4.0
+      svg-tags: 1.0.0
+      table: 6.9.0
+      write-file-atomic: 7.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  supports-color@10.2.2: {}
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -11399,7 +11911,14 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@4.4.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
+
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svg-tags@1.0.0: {}
 
   svgo@3.3.2:
     dependencies:
@@ -11412,6 +11931,14 @@ snapshots:
       picocolors: 1.1.1
 
   symbol-tree@3.2.4: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.17.1
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   tar@6.2.1:
     dependencies:
@@ -11552,6 +12079,8 @@ snapshots:
     dependencies:
       pako: 0.2.9
       tiny-inflate: 1.0.3
+
+  unicorn-magic@0.4.0: {}
 
   unified@10.1.2:
     dependencies:
@@ -12018,6 +12547,10 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
 
   ws@8.18.2: {}
 

--- a/src/features/Footer/index.module.css
+++ b/src/features/Footer/index.module.css
@@ -3,26 +3,26 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2rem;
-  padding: 96px 16px;
+  gap: var(--spacing-xl);
+  padding: 96px var(--spacing-md);
   position: relative;
   z-index: 100;
 }
 
 .title {
-  font-size: 2rem;
+  font-size: var(--font-size-heading-xl);
   font-weight: 900;
 }
 
 .accounts {
   display: flex;
   flex-wrap: wrap;
-  gap: 40px;
+  gap: 40px; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
 }
 
 @media screen and (max-width: 1000px) {
   .accounts {
-    gap: 24px;
+    gap: var(--spacing-lg);
   }
   .icon {
     width: 44px;
@@ -43,5 +43,5 @@
   color: var(--color-link);
   text-decoration: underline;
   position: absolute;
-  bottom: 16px;
+  bottom: var(--spacing-md);
 } 

--- a/src/features/Header/index.module.css
+++ b/src/features/Header/index.module.css
@@ -6,43 +6,43 @@
 }
 
 .logo {
-  font-size: 1.5rem;
+  font-size: var(--font-size-heading-md);
   font-weight: bold;
   line-height: 1;
   position: fixed;
   top: 21px;
-  left: 32px;
+  left: var(--spacing-xl);
   z-index: 10000000;
 }
 
 @media screen and (max-width: 1000px) {
   .logo {
-    left: 16px;
+    left: var(--spacing-md);
   }
 }
 
 .nav {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--spacing-md);
   position: fixed;
-  top: 16px;
-  right: 32px;
+  top: var(--spacing-md);
+  right: var(--spacing-xl);
   z-index: 10000000;
   font-weight: bold;
 }
 
 @media screen and (max-width: 1000px) {
   .nav {
-    gap: 8px;
-    top: 8px;
-    right: 16px;
+    gap: var(--spacing-xs);
+    top: var(--spacing-xs);
+    right: var(--spacing-md);
   }
 }
 
 .navLinks {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-md);
 }
 
 @media screen and (max-width: 1000px) {
@@ -85,10 +85,10 @@
   content: "";
   display: block;
   width: 100%;
-  height: 4px;
+  height: var(--spacing-xxs);
   background-color: var(--color-link);
   position: absolute;
-  bottom: -8px;
+  bottom: calc(-1 * var(--spacing-xs));
 }
 
 .spMenu {
@@ -107,23 +107,23 @@
   left: 0;
   right: 0;
   background-color: var(--color-background);
-  padding: 16px;
+  padding: var(--spacing-md);
   z-index: 10000001;
 }
 
 .close {
     position: fixed;
-    top: 8px;
-    right: 16px;
+    top: var(--spacing-xs);
+    right: var(--spacing-md);
   }
 
   .spNav {
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: var(--spacing-xl);
 
     a {
-      font-size: 1.5rem;
+      font-size: var(--font-size-heading-md);
       font-weight: bold;
       width: fit-content;
 

--- a/src/pages/_components/TopAboutMe.astro
+++ b/src/pages/_components/TopAboutMe.astro
@@ -29,7 +29,7 @@ import { LinkButton } from "../../ui/LinkButton";
 <style>
   .about {
     display: flex;
-    gap: 64px;
+    gap: var(--spacing-xxl);
     justify-content: center;
     align-items: center;
 
@@ -48,7 +48,7 @@ import { LinkButton } from "../../ui/LinkButton";
         width: 300px;
         height: 187.5px;
         background-color: var(--color-white);
-        border-radius: 16px;
+        border-radius: var(--radius-xl);
         border: 8px solid var(--color-white);
         position: relative;
 
@@ -60,7 +60,7 @@ import { LinkButton } from "../../ui/LinkButton";
           width: 100%;
           height: 100%;
           object-fit: cover;
-          border-radius: 8px;
+          border-radius: var(--radius-md);
         }
       }
 
@@ -82,7 +82,7 @@ import { LinkButton } from "../../ui/LinkButton";
         font-weight: 900;
 
         @media screen and (max-width: 1000px) {
-          font-size: 2rem;
+          font-size: var(--font-size-heading-xl);
         }
       }
     }

--- a/src/pages/_components/TopAnimation.astro
+++ b/src/pages/_components/TopAnimation.astro
@@ -83,7 +83,7 @@ import { AnimationIcon } from "../../features/AnimationIcon";
     height: 20vh;
     min-height: 180px;
     background-color: var(--color-background);
-    border-radius: 16px;
+    border-radius: var(--radius-xl);
     border: 8px solid var(--color-background);
     position: fixed;
     top: 50%;
@@ -138,7 +138,7 @@ import { AnimationIcon } from "../../features/AnimationIcon";
       top: 1.8rem;
       left: 50%;
       transform: translateX(-50%);
-      width: 2px;
+      width: var(--spacing-xxxs);
       height: 36px;
       background: var(--color-text);
       animation: pathmove 1.5s ease-in-out infinite;
@@ -168,12 +168,12 @@ import { AnimationIcon } from "../../features/AnimationIcon";
 
   .animation-button {
     position: fixed;
-    bottom: 32px;
-    right: 32px;
+    bottom: var(--spacing-xl);
+    right: var(--spacing-xl);
 
     @media screen and (max-width: 1000px) {
-      bottom: 16px;
-      right: 16px;
+      bottom: var(--spacing-md);
+      right: var(--spacing-md);
     }
   }
 </style>

--- a/src/pages/_components/TopArticles.astro
+++ b/src/pages/_components/TopArticles.astro
@@ -48,7 +48,7 @@ const allPosts = await getAllPosts();
         line-height: 1;
 
         @media screen and (max-width: 1000px) {
-          font-size: 2rem;
+          font-size: var(--font-size-heading-xl);
         }
       }
     }

--- a/src/pages/_components/TopProducts.astro
+++ b/src/pages/_components/TopProducts.astro
@@ -50,7 +50,7 @@ const productsCollection = (await getCollection("products")).sort((a, b) =>
         line-height: 1;
 
         @media screen and (max-width: 1000px) {
-          font-size: 2rem;
+          font-size: var(--font-size-heading-xl);
         }
       }
     }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -78,7 +78,7 @@ import { Image } from "astro:assets";
       display: flex;
       flex-direction: column;
       align-items: center;
-      padding: 0rem 16px;
+      padding: 0rem var(--spacing-md);
       width: 100%;
     }
 
@@ -113,12 +113,12 @@ import { Image } from "astro:assets";
     }
     .h2 {
       margin-top: 4rem;
-      font-size: 2rem;
+      font-size: var(--font-size-heading-xl);
       font-weight: 900;
     }
 
     .h3 {
-      font-size: 1.5rem;
+      font-size: var(--font-size-heading-md);
       font-weight: 900;
     }
 
@@ -148,7 +148,7 @@ import { Image } from "astro:assets";
         width: 100%;
         height: 100%;
         object-fit: cover;
-        border-radius: 8px;
+        border-radius: var(--radius-md);
         position: sticky;
         top: 5rem;
       }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,7 +38,7 @@ import TopArticles from "./_components/TopArticles.astro";
       display: flex;
       justify-content: center;
       .main {
-        padding: 48px 16px 96px 16px;
+        padding: 48px var(--spacing-md) 96px var(--spacing-md);
         overflow: hidden;
         display: flex;
         flex-direction: column;

--- a/src/pages/posts.astro
+++ b/src/pages/posts.astro
@@ -35,14 +35,14 @@ const allPosts = await getAllPosts();
   .container {
     display: flex;
     flex-direction: column;
-    padding: 0 16px;
+    padding: 0 var(--spacing-md);
     align-items: center;
     .articles {
-      padding-top: 64px;
+      padding-top: var(--spacing-xxl);
       padding-bottom: 96px;
       display: grid;
       grid-template-columns: repeat(3, 1fr);
-      gap: 64px 48px;
+      gap: var(--spacing-xxl) 48px;
       list-style: none;
       max-width: 70rem;
       width: 100%;

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -87,7 +87,7 @@ import CommonHead from "../../components/CommonHead.astro";
         width: 100%;
         max-width: calc(70rem + 2rem);
         margin: 0 auto;
-        padding: 96px 16px;
+        padding: 96px var(--spacing-md);
       }
     </style>
   </body>

--- a/src/pages/posts/_components/BlogPost/TableOfContents.astro
+++ b/src/pages/posts/_components/BlogPost/TableOfContents.astro
@@ -42,7 +42,7 @@ const { headings } = Astro.props;
     }
 
     .toc-title {
-      font-size: 1.25rem;
+      font-size: var(--font-size-heading-sm);
       font-weight: 700;
       margin-bottom: 1rem;
     }

--- a/src/pages/posts/_components/BlogPost/content.css
+++ b/src/pages/posts/_components/BlogPost/content.css
@@ -2,14 +2,14 @@
   grid-area: content;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-md);
   width: 100%;
 
   /* pc */
   @media screen and (min-width: 1001px) {
     background-color: var(--color-white);
     padding: 2rem;
-    border-radius: 0.5rem;
+    border-radius: var(--radius-md);
   }
 
   .slide-container {
@@ -22,25 +22,25 @@
       padding: 2rem;
       background: var(--color-background);
       border: 1px solid var(--color-text);
-      border-radius: 0.5rem;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-elevation-4);
     }
 
     :global(h1) {
-      font-size: 2.5rem;
+      font-size: var(--font-size-title-md);
       font-weight: 900;
       margin-bottom: 1rem;
       color: var(--color-link);
     }
 
     :global(h2) {
-      font-size: 2rem;
+      font-size: var(--font-size-heading-xl);
       font-weight: 700;
       margin-bottom: 1rem;
     }
 
     :global(h3) {
-      font-size: 1.5rem;
+      font-size: var(--font-size-heading-md);
       font-weight: 600;
       margin-bottom: 0.5rem;
     }
@@ -58,7 +58,7 @@
       background-color: var(--color-text);
       color: var(--color-background);
       padding: 0.25rem 0.5rem;
-      border-radius: 0.25rem;
+      border-radius: var(--radius-sm);
       font-family: "Courier New", monospace;
     }
 
@@ -66,7 +66,7 @@
       background-color: var(--color-text);
       color: var(--color-background);
       padding: 1rem;
-      border-radius: 0.5rem;
+      border-radius: var(--radius-md);
       overflow-x: auto;
       margin: 1rem 0;
     }
@@ -79,19 +79,19 @@
 
   h2 {
     margin-top: 2rem;
-    font-size: 2rem;
+    font-size: var(--font-size-heading-xl);
     font-weight: 900;
   }
 
   h3 {
     margin-top: 1rem;
-    font-size: 1.5rem;
+    font-size: var(--font-size-heading-md);
     font-weight: 900;
   }
 
   h4 {
     margin-top: 0.5rem;
-    font-size: 1.25rem;
+    font-size: var(--font-size-heading-sm);
     font-weight: 900;
   }
 
@@ -103,7 +103,7 @@
   ul {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: var(--spacing-xs);
     padding-left: 1.5rem;
 
     li {
@@ -116,7 +116,7 @@
   ol {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: var(--spacing-xs);
     padding-left: 1.5rem;
 
     li {
@@ -133,7 +133,7 @@
 
   em {
     font-style: normal;
-    font-size: 0.875rem;
+    font-size: var(--font-size-body-sm);
   }
 
   th,
@@ -152,9 +152,9 @@
     background-color: var(--color-text);
     color: var(--color-background);
     padding: 0.25rem 0.5rem;
-    border-radius: 0.25rem;
+    border-radius: var(--radius-sm);
     margin: 0 0.25rem;
-    font-size: 0.875rem;
+    font-size: var(--font-size-body-sm);
   }
 
   pre {

--- a/src/pages/posts/_components/BlogPost/index.astro
+++ b/src/pages/posts/_components/BlogPost/index.astro
@@ -100,12 +100,12 @@ const { post, Content, headings } = Astro.props;
         color: var(--color-background);
         padding: 0.25rem 0.5rem;
         border-radius: 0.25rem;
-        font-size: 0.875rem;
+        font-size: var(--font-size-body-sm);
         font-weight: bold;
       }
 
       .title {
-        font-size: 2rem;
+        font-size: var(--font-size-heading-xl);
         font-weight: 900;
       }
 

--- a/src/pages/posts/_components/Comments.astro
+++ b/src/pages/posts/_components/Comments.astro
@@ -60,7 +60,7 @@
   }
 
   .heading {
-    font-size: 1.5rem;
+    font-size: var(--font-size-heading-md);
     font-weight: 700;
     margin-bottom: 1.5rem;
   }

--- a/src/pages/posts/_components/SlideControls.module.css
+++ b/src/pages/posts/_components/SlideControls.module.css
@@ -1,19 +1,19 @@
 .controls {
   position: fixed;
-  bottom: 24px;
+  bottom: var(--spacing-lg);
   left: 50%;
   transform: translateX(-50%);
   z-index: 9999;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-xs);
   background-color: rgba(4, 27, 71, 0.78);
-  color: #fff;
-  padding: 8px 14px;
-  border-radius: 999px;
+  color: var(--color-white);
+  padding: var(--spacing-xs) 14px;
+  border-radius: var(--radius-infinity);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18); /* stylelint-disable-line scale-unlimited/declaration-strict-value */
 }
 
 .btn {
@@ -24,8 +24,8 @@
   justify-content: center;
   border-radius: 50%;
   background-color: rgba(255, 255, 255, 0.16);
-  color: #fff;
-  font-size: 1.1rem;
+  color: var(--color-white);
+  font-size: 1.1rem; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
   border: none;
   cursor: pointer;
   transition: background-color 0.15s ease;
@@ -36,8 +36,8 @@
 }
 
 .btn:focus-visible {
-  outline: 2px solid #fff;
-  outline-offset: 2px;
+  outline: var(--border-width-lg) solid var(--color-white);
+  outline-offset: var(--spacing-xxxs);
 }
 
 .btn:disabled {
@@ -46,7 +46,7 @@
 }
 
 .indicator {
-  font-size: 0.875rem;
+  font-size: var(--font-size-body-sm);
   font-weight: 700;
   min-width: 56px;
   text-align: center;

--- a/src/pages/products.astro
+++ b/src/pages/products.astro
@@ -37,23 +37,23 @@ const productsCollection = (await getCollection("products")).sort((a, b) =>
       display: flex;
       flex-direction: column;
       align-items: center;
-      padding: 0rem 16px;
+      padding: 0rem var(--spacing-md);
 
       .products {
         /* grid 2つ並べて折り返す*/
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         max-width: 70rem;
-        padding-top: 64px;
+        padding-top: var(--spacing-xxl);
         padding-bottom: 96px;
         width: 100%;
 
         > *:nth-child(odd) {
-          padding: 32px 24px 64px 0;
+          padding: var(--spacing-xl) var(--spacing-lg) var(--spacing-xxl) 0;
         }
 
         > *:nth-child(even) {
-          padding: 96px 0 0 24px;
+          padding: 96px 0 0 var(--spacing-lg);
         }
 
         @media screen and (max-width: 1000px) {

--- a/src/pages/products/[slug].astro
+++ b/src/pages/products/[slug].astro
@@ -64,7 +64,7 @@ import CommonHead from "../../components/CommonHead.astro";
         width: 100%;
         max-width: calc(50rem + 2rem);
         margin: 0 auto;
-        padding: 96px 16px;
+        padding: 96px var(--spacing-md);
       }
       .breadcrumbs {
         display: flex;
@@ -75,7 +75,7 @@ import CommonHead from "../../components/CommonHead.astro";
         background-color: var(--color-white);
         height: fit-content;
         width: fit-content;
-        border-radius: 9999px;
+        border-radius: var(--radius-infinity);
 
         @media screen and (max-width: 1000px) {
           width: 100%;

--- a/src/pages/products/_components/ProductPost/index.astro
+++ b/src/pages/products/_components/ProductPost/index.astro
@@ -94,13 +94,13 @@ const { product, Content } = Astro.props;
     width: 100%;
 
     .post-meta {
-      font-size: 0.875rem;
+      font-size: var(--font-size-body-sm);
       color: var(--color-text);
       opacity: 0.6;
     }
 
     .title {
-      font-size: 2rem;
+      font-size: var(--font-size-heading-xl);
       font-weight: 900;
       text-align: center;
     }
@@ -138,7 +138,7 @@ const { product, Content } = Astro.props;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
     border: solid 1px var(--color-text);
-    border-radius: 9999px;
+    border-radius: var(--radius-infinity);
     text-decoration: none;
     color: var(--color-text);
     background-color: var(--color-white);
@@ -160,7 +160,7 @@ const { product, Content } = Astro.props;
   .tech-badge {
     padding: 0.25rem 0.75rem;
     background-color: var(--color-white);
-    border-radius: 9999px;
-    font-size: 0.875rem;
+    border-radius: var(--radius-infinity);
+    font-size: var(--font-size-label-sm);
   }
 </style>

--- a/src/pages/siteMap.astro
+++ b/src/pages/siteMap.astro
@@ -34,10 +34,10 @@ const allPosts = await getCollection("posts");
   .container {
     display: flex;
     flex-direction: column;
-    padding: 0 16px;
+    padding: 0 var(--spacing-md);
     align-items: center;
     .links {
-      padding-top: 64px;
+      padding-top: var(--spacing-xxl);
       padding-bottom: 96px;
       width: 100%;
       max-width: 70rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -112,7 +112,7 @@ html {
     "Hiragino Sans",
     Meiryo,
     sans-serif;
-  font-size: 1rem;
+  font-size: 1rem; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
   line-height: 1.5;
 
   body {

--- a/src/ui/BlogPost/index.module.css
+++ b/src/ui/BlogPost/index.module.css
@@ -4,7 +4,7 @@
 .link {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-md);
   width: 100%;
 }
 .mask {
@@ -24,30 +24,30 @@
 .texts {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-xs);
 }
 .meta {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-body-sm);
 }
 .slideBadge {
   background-color: var(--color-link);
   color: var(--color-background);
   padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
-  font-size: 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-body-xs);
   font-weight: bold;
 }
 .title {
-  font-size: 1.125rem;
+  font-size: 1.125rem; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
   font-weight: 700;
 }
 .icon {
   display: inline;
   vertical-align: -0.125em;
-  margin-left: 2px;
+  margin-left: var(--spacing-xxxs);
 }
 .link:hover .image {
   transform: scale(1.1);

--- a/src/ui/Breadcrumb/index.module.css
+++ b/src/ui/Breadcrumb/index.module.css
@@ -3,7 +3,7 @@
   background-color: var(--color-white);
   height: fit-content;
   width: fit-content;
-  border-radius: 9999px;
+  border-radius: var(--radius-infinity);
   list-style: none;
   margin: 0;
 }

--- a/src/ui/IconButton/index.module.css
+++ b/src/ui/IconButton/index.module.css
@@ -1,7 +1,7 @@
 .button {
   width: 44px;
   height: 44px;
-  border-radius: 9999px;
+  border-radius: var(--radius-infinity);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/ui/LinkButton/index.module.css
+++ b/src/ui/LinkButton/index.module.css
@@ -3,7 +3,7 @@
   border: solid 1px var(--color-text);
   color: var(--color-text);
   background-color: var(--color-white);
-  border-radius: 9999px;
+  border-radius: var(--radius-infinity);
   width: fit-content;
   display: flex;
   align-items: center;

--- a/src/ui/PageTitle/index.module.css
+++ b/src/ui/PageTitle/index.module.css
@@ -15,7 +15,7 @@
 @media screen and (max-width: 1000px) {
   .wrapper {
     flex-direction: column;
-    gap: 2rem;
+    gap: var(--spacing-xl);
     align-items: flex-start;
   }
 }
@@ -24,7 +24,7 @@
   z-index: 1;
 }
 .title {
-  font-size: 96px;
+  font-size: 96px; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
   font-weight: 700;
   line-height: 1;
   background-color: var(--color-background);
@@ -33,7 +33,7 @@
 }
 @media screen and (max-width: 1000px) {
   .title {
-    font-size: 2rem;
+    font-size: var(--font-size-heading-xl);
   }
 }
 .line {

--- a/src/ui/ProductItem/index.module.css
+++ b/src/ui/ProductItem/index.module.css
@@ -4,7 +4,7 @@
   flex-direction: column;
   align-items: end;
   justify-content: center;
-  gap: 24px;
+  gap: var(--spacing-lg);
 }
 .index-parent {
   position: relative;
@@ -13,7 +13,7 @@
   height: auto;
 }
 .index {
-  font-size: 96px;
+  font-size: 96px; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
   font-weight: 700;
   position: absolute;
   bottom: -64px;
@@ -23,12 +23,12 @@
   overflow: hidden;
   display: block;
   line-height: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   width: 100%;
   aspect-ratio: 8/5;
 }
 .image {
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   aspect-ratio: 8/5;
   width: 100%;
   height: 100%;
@@ -39,13 +39,13 @@
   display: flex;
   flex-direction: column;
   align-items: end;
-  gap: 16px;
+  gap: var(--spacing-md);
   text-align: right;
 }
 .link {
   text-decoration: none;
   color: inherit;
-  font-size: 1.5rem;
+  font-size: var(--font-size-heading-md);
   font-weight: 700;
 }
 .product:hover .image {


### PR DESCRIPTION
## 概要

CSS ファイル全体で、ハードコードされた値の代わりに CSS カスタムプロパティ（`var(--...)`）を使用するよう統一しました。stylelint と `stylelint-declaration-strict-value` プラグインを導入し、今後のコード品質を保証します。

## 変更内容

- **stylelint 設定追加** (`.stylelintrc.json`)
  - `stylelint-declaration-strict-value` プラグインを使用
  - `color`, `background-color`, `border-color`, `font-size`, `border-radius`, `gap`, `box-shadow` に対して CSS カスタムプロパティの使用を強制
  - 一部の例外値（`inherit`, `transparent`, `0`, `50%` など）は許可

- **既存 CSS ファイルの統一**
  - Header, Footer, BlogPost, SlideControls など複数のコンポーネントで、ハードコードされた値を対応する CSS カスタムプロパティに置き換え
  - 例: `1.5rem` → `var(--font-size-heading-md)`, `16px` → `var(--spacing-md)`, `0.5rem` → `var(--radius-md)`
  - 一部の値（大きなフォントサイズ `96px`、特定の `gap` 値など）には `/* stylelint-disable-line scale-unlimited/declaration-strict-value */` コメントを追加

- **package.json 更新**
  - `check` スクリプトに stylelint を追加
  - `check:css` スクリプトを新規追加（CSS チェック専用）
  - `stylelint` と `stylelint-declaration-strict-value` を devDependencies に追加

## 確認事項

- [x] ローカルで動作確認済み
- [x] `pnpm run check` (Biome + stylelint) がパスする
- [x] `pnpm run test:unit` がパスする

https://claude.ai/code/session_013zMqPjkdVYRmbKvrvGmjVV