### PR TITLE
chore(deps): TypeScript を 6.0.3 にメジャー更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "satori": "^0.10.14",
     "sharp": "^0.34.3",
     "the-new-css-reset": "^1.11.2",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@astrojs/check':
         specifier: ^0.5.10
-        version: 0.5.10(typescript@5.8.3)
+        version: 0.5.10(typescript@6.0.3)
       '@astrojs/mdx':
         specifier: ^2.3.1
-        version: 2.3.1(astro@4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@5.8.3))
+        version: 2.3.1(astro@4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@6.0.3))
       '@astrojs/react':
         specifier: ^3.6.0
         version: 3.6.3(@types/node@22.15.30)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -52,13 +52,13 @@ importers:
         version: 18.3.7(@types/react@18.3.23)
       astro:
         specifier: ^4.6.3
-        version: 4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@5.8.3)
+        version: 4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@6.0.3)
       astro-icon:
         specifier: ^1.1.0
         version: 1.1.5
       astro-seo:
         specifier: ^0.8.4
-        version: 0.8.4(typescript@5.8.3)
+        version: 0.8.4(typescript@6.0.3)
       destyle.css:
         specifier: ^4.0.1
         version: 4.0.1
@@ -87,8 +87,8 @@ importers:
         specifier: ^1.11.2
         version: 1.11.3
       typescript:
-        specifier: ^5.4.5
-        version: 5.8.3
+        specifier: ^6.0.3
+        version: 6.0.3
     devDependencies:
       '@biomejs/biome':
         specifier: 1.8.3
@@ -110,10 +110,10 @@ importers:
         version: 9.0.6(@vitest/browser@3.2.2)(@vitest/runner@3.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0))(vitest@3.2.2)
       '@storybook/react':
         specifier: ^9.0.0
-        version: 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@5.8.3)
+        version: 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: ^9.0.0
-        version: 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.42.0)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(yaml@2.8.0))
+        version: 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.42.0)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@6.0.3)(vite@6.3.5(@types/node@22.15.30)(yaml@2.8.0))
       '@storybook/test-runner':
         specifier: ^0.22.0
         version: 0.22.1(@types/node@22.15.30)(storybook@9.0.6(@testing-library/dom@10.4.0))
@@ -5062,8 +5062,8 @@ packages:
   typescript-auto-import-cache@0.3.6:
     resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5650,13 +5650,13 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@astrojs/check@0.5.10(typescript@5.8.3)':
+  '@astrojs/check@0.5.10(typescript@6.0.3)':
     dependencies:
-      '@astrojs/language-server': 2.15.4(typescript@5.8.3)
+      '@astrojs/language-server': 2.15.4(typescript@6.0.3)
       chokidar: 3.6.0
       fast-glob: 3.3.3
       kleur: 4.1.5
-      typescript: 5.8.3
+      typescript: 6.0.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - prettier
@@ -5666,12 +5666,12 @@ snapshots:
 
   '@astrojs/internal-helpers@0.4.1': {}
 
-  '@astrojs/language-server@2.15.4(typescript@5.8.3)':
+  '@astrojs/language-server@2.15.4(typescript@6.0.3)':
     dependencies:
       '@astrojs/compiler': 2.12.1
       '@astrojs/yaml2ts': 0.2.2
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@volar/kit': 2.4.14(typescript@5.8.3)
+      '@volar/kit': 2.4.14(typescript@6.0.3)
       '@volar/language-core': 2.4.14
       '@volar/language-server': 2.4.14
       '@volar/language-service': 2.4.14
@@ -5735,12 +5735,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@2.3.1(astro@4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@5.8.3))':
+  '@astrojs/mdx@2.3.1(astro@4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@6.0.3))':
     dependencies:
       '@astrojs/markdown-remark': 5.1.0
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       acorn: 8.14.1
-      astro: 4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@5.8.3)
+      astro: 4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@6.0.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       github-slugger: 2.0.0
@@ -6679,14 +6679,14 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.0(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(yaml@2.8.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.0(typescript@6.0.3)(vite@6.3.5(@types/node@22.15.30)(yaml@2.8.0))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.17
-      react-docgen-typescript: 2.2.2(typescript@5.8.3)
+      react-docgen-typescript: 2.2.2(typescript@6.0.3)
       vite: 6.3.5(@types/node@22.15.30)(yaml@2.8.0)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 6.0.3
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -7034,12 +7034,12 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 9.0.6(@testing-library/dom@10.4.0)
 
-  '@storybook/react-vite@9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.42.0)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(yaml@2.8.0))':
+  '@storybook/react-vite@9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.42.0)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@6.0.3)(vite@6.3.5(@types/node@22.15.30)(yaml@2.8.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.0(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(yaml@2.8.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.0(typescript@6.0.3)(vite@6.3.5(@types/node@22.15.30)(yaml@2.8.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.42.0)
       '@storybook/builder-vite': 9.0.6(storybook@9.0.6(@testing-library/dom@10.4.0))(vite@6.3.5(@types/node@22.15.30)(yaml@2.8.0))
-      '@storybook/react': 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@5.8.3)
+      '@storybook/react': 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@6.0.3)
       find-up: 5.0.0
       magic-string: 0.30.17
       react: 18.3.1
@@ -7054,7 +7054,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@5.8.3)':
+  '@storybook/react@9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 9.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.6(@testing-library/dom@10.4.0))
@@ -7062,7 +7062,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 9.0.6(@testing-library/dom@10.4.0)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 6.0.3
 
   '@storybook/test-runner@0.22.1(@types/node@22.15.30)(storybook@9.0.6(@testing-library/dom@10.4.0))':
     dependencies:
@@ -7459,12 +7459,12 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@volar/kit@2.4.14(typescript@5.8.3)':
+  '@volar/kit@2.4.14(typescript@6.0.3)':
     dependencies:
       '@volar/language-service': 2.4.14
       '@volar/typescript': 2.4.14
       typesafe-path: 0.2.2
-      typescript: 5.8.3
+      typescript: 6.0.3
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -7616,15 +7616,15 @@ snapshots:
       - debug
       - supports-color
 
-  astro-seo@0.8.4(typescript@5.8.3):
+  astro-seo@0.8.4(typescript@6.0.3):
     dependencies:
-      '@astrojs/check': 0.5.10(typescript@5.8.3)
+      '@astrojs/check': 0.5.10(typescript@6.0.3)
     transitivePeerDependencies:
       - prettier
       - prettier-plugin-astro
       - typescript
 
-  astro@4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@5.8.3):
+  astro@4.16.18(@types/node@22.15.30)(rollup@4.42.0)(typescript@6.0.3):
     dependencies:
       '@astrojs/compiler': 2.12.1
       '@astrojs/internal-helpers': 0.4.1
@@ -7677,7 +7677,7 @@ snapshots:
       semver: 7.7.2
       shiki: 1.29.2
       tinyexec: 0.3.2
-      tsconfck: 3.1.6(typescript@5.8.3)
+      tsconfck: 3.1.6(typescript@6.0.3)
       unist-util-visit: 5.0.0
       vfile: 6.0.3
       vite: 5.4.19(@types/node@22.15.30)
@@ -7687,7 +7687,7 @@ snapshots:
       yargs-parser: 21.1.1
       zod: 3.25.56
       zod-to-json-schema: 3.24.5(zod@3.25.56)
-      zod-to-ts: 1.2.0(typescript@5.8.3)(zod@3.25.56)
+      zod-to-ts: 1.2.0(typescript@6.0.3)(zod@3.25.56)
     optionalDependencies:
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -10745,9 +10745,9 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-docgen-typescript@2.2.2(typescript@5.8.3):
+  react-docgen-typescript@2.2.2(typescript@6.0.3):
     dependencies:
-      typescript: 5.8.3
+      typescript: 6.0.3
 
   react-docgen@8.0.0:
     dependencies:
@@ -11497,9 +11497,9 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  tsconfck@3.1.6(typescript@5.8.3):
+  tsconfck@3.1.6(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 6.0.3
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -11529,7 +11529,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
-  typescript@5.8.3: {}
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -12109,9 +12109,9 @@ snapshots:
     dependencies:
       zod: 3.25.56
 
-  zod-to-ts@1.2.0(typescript@5.8.3)(zod@3.25.56):
+  zod-to-ts@1.2.0(typescript@6.0.3)(zod@3.25.56):
     dependencies:
-      typescript: 5.8.3
+      typescript: 6.0.3
       zod: 3.25.56
 
   zod@3.25.56: {}


### PR DESCRIPTION
## 概要

TypeScript を 5 系から 6 系へメジャー更新する。依存関係更新計画の PR#3 にあたる。
プロジェクトで現在使用していた `^5.4.5` は実質 5.8.3 で固まっており、TypeScript 6 のリリースに追随する。

Astro 4 系の一部の推移的依存（`tsconfck`, `zod-to-ts`, `@astrojs/check 0.5`）が peer dependency として TypeScript 5 を要求しているが、`astro check` と `astro build` は正常に動作することを確認済み。これらは後続の Astro メジャー更新 PR で解消される見込み。

## 変更内容

- `package.json`: `typescript` を `^5.4.5` → `^6.0.3` に更新
- `pnpm-lock.yaml`: TypeScript 6 への依存解決を反映

## 確認事項

- [x] ローカルで動作確認済み（`pnpm build` で 19 ページ生成成功）
- [x] `pnpm run check` (Biome) がパスする
- [x] `pnpm run test:unit` がパスする（38/38 passed）
- [x] `pnpm exec astro check`: 0 errors / 0 warnings

## スクリーンショット（UI変更がある場合）

UI 変更なし