### PR TITLE
refactor(css): z-index をカスタムプロパティで体系化

### DIFF
--- a/src/features/Footer/index.module.css
+++ b/src/features/Footer/index.module.css
@@ -6,7 +6,7 @@
   gap: var(--spacing-xl);
   padding: 96px var(--spacing-md);
   position: relative;
-  z-index: 100;
+  z-index: var(--z-index-content);
 }
 
 .title {

--- a/src/features/Header/index.module.css
+++ b/src/features/Header/index.module.css
@@ -12,7 +12,7 @@
   position: fixed;
   top: 21px;
   left: var(--spacing-xl);
-  z-index: 10000000;
+  z-index: var(--z-index-header);
 }
 
 @media screen and (max-width: 1000px) {
@@ -28,7 +28,7 @@
   position: fixed;
   top: var(--spacing-md);
   right: var(--spacing-xl);
-  z-index: 10000000;
+  z-index: var(--z-index-header);
   font-weight: bold;
 }
 
@@ -108,7 +108,7 @@
   right: 0;
   background-color: var(--color-background);
   padding: var(--spacing-md);
-  z-index: 10000001;
+  z-index: var(--z-index-modal);
 }
 
 .close {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,7 +33,7 @@ import TopArticles from "./_components/TopArticles.astro";
     .background {
       margin-top: 50vh;
       position: relative;
-      z-index: 1000000;
+      z-index: var(--z-index-content);
       width: 100%;
       display: flex;
       justify-content: center;

--- a/src/pages/posts/_components/SlideControls.module.css
+++ b/src/pages/posts/_components/SlideControls.module.css
@@ -3,7 +3,7 @@
   bottom: var(--spacing-lg);
   left: 50%;
   transform: translateX(-50%);
-  z-index: 9999;
+  z-index: var(--z-index-toast);
   display: flex;
   align-items: center;
   gap: var(--spacing-xs);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -87,6 +87,13 @@
   --shadow-elevation-8: 0px 8px 20px 0px rgba(0, 0, 0, 0.15);
   --shadow-elevation-12: 0px 16px 30px 0px rgba(0, 0, 0, 0.15);
 
+  /* z-index */
+  --z-index-background: 0;
+  --z-index-content: 10;
+  --z-index-header: 100;
+  --z-index-modal: 200;
+  --z-index-toast: 300;
+
   /* Font Family */
   --font-family-default: "BIZ UDPGothic", sans-serif;
 


### PR DESCRIPTION
global.css に z-index スケール（background/content/header/modal/toast）を
定義し、各所のマジックナンバーを意味のある変数に置き換え。

- index.astro .background (1000000) → --z-index-content
- Footer .footer (100) → --z-index-content
- Header .logo/.nav (10000000) → --z-index-header
- Header .spMenu.open (10000001) → --z-index-modal
- SlideControls .controls (9999) → --z-index-toast

TopAnimation / PageTitle の z-index:1,2 はコンポーネント内のローカルな
重なり順のため変更せず据え置き。

https://claude.ai/code/session_01BLhdu6VxcVfeSfxWcTkJm8