### PR TITLE
chore(dependabot): エコシステム別グループ化と github-actions 追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,89 @@
-# Please see the documentation for all configuration options:
+# Dependabot configuration
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: "pnpm" # See documentation for possible values
+  # npm/pnpm 依存
+  # patch/minor はエコシステム単位でグループ化して PR 数を抑制する。
+  # major は破壊的変更を含むため意図的に個別 PR で扱う。
+  - package-ecosystem: "pnpm"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+          - "astro-icon"
+          - "astro-seo"
+        update-types:
+          - "minor"
+          - "patch"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+        update-types:
+          - "minor"
+          - "patch"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+          - "storybook-addon-*"
+        update-types:
+          - "minor"
+          - "patch"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+        update-types:
+          - "minor"
+          - "patch"
+      testing:
+        patterns:
+          - "@testing-library/*"
+          - "jsdom"
+          - "@types/jsdom"
+          - "playwright"
+        update-types:
+          - "minor"
+          - "patch"
+      iconify:
+        patterns:
+          - "@iconify-json/*"
+          - "react-icons"
+        update-types:
+          - "minor"
+          - "patch"
+      tooling:
+        patterns:
+          - "typescript"
+          - "@biomejs/biome"
+          - "stylelint"
+          - "stylelint-*"
+          - "plop"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions の更新も自動化
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## 概要

依存関係更新計画の Phase 3（最終フェーズ）。最低限の構成だった `.github/dependabot.yml` を運用に耐える形に拡張する。

これまでの構成では各パッケージ更新が個別 PR になり PR 数が爆発するため、パッチ・マイナーをエコシステム単位でグループ化。メジャー更新は意図的に個別 PR として扱い、破壊的変更を含むため個別にレビューできるようにする。

## 想定される動作

設定反映後、月曜の週次実行時に：

1. グループ化されたエコシステムごとに最大 1 PR ずつ（パッチ/マイナー）
2. メジャー更新がある場合はパッケージごとに別 PR
3. GitHub Actions に更新があれば actions グループで 1 PR

## 確認事項

- [x] YAML 構文として valid（`yaml.parse` で検証済み）
- [x] groups パターンの記述形式は Dependabot の公式仕様に準拠