### PR TITLE
utopiaに従ってデザイン見直し

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -9,7 +9,17 @@
         "font-size",
         "border-radius",
         "gap",
-        "box-shadow"
+        "box-shadow",
+        "padding",
+        "padding-top",
+        "padding-bottom",
+        "padding-left",
+        "padding-right",
+        "margin",
+        "margin-top",
+        "margin-bottom",
+        "margin-left",
+        "margin-right"
       ],
       {
         "ignoreValues": [
@@ -19,9 +29,11 @@
           "currentColor",
           "transparent",
           "none",
+          "auto",
           "0",
           "50%",
-          "100%"
+          "100%",
+          "50vh"
         ],
         "disableFix": true,
         "message": "Use a CSS custom property (var(--...)) instead of a hardcoded value for \"${property}\""

--- a/src/features/Footer/index.module.css
+++ b/src/features/Footer/index.module.css
@@ -3,26 +3,26 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--spacing-xl);
-  padding: 96px var(--spacing-md);
+  gap: var(--space-l);
+  padding: var(--space-3xl) var(--space-s);
   position: relative;
   z-index: var(--z-index-content);
 }
 
 .title {
-  font-size: var(--font-size-heading-xl);
+  font-size: var(--step-2);
   font-weight: 900;
 }
 
 .accounts {
   display: flex;
   flex-wrap: wrap;
-  gap: 40px; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
+  gap: var(--space-l);
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1024px) /* sync with --bp-md */ {
   .accounts {
-    gap: var(--spacing-lg);
+    gap: var(--space-m);
   }
   .icon {
     width: 44px;
@@ -43,5 +43,5 @@
   color: var(--color-link);
   text-decoration: underline;
   position: absolute;
-  bottom: var(--spacing-md);
+  bottom: var(--space-s);
 } 

--- a/src/features/Header/index.module.css
+++ b/src/features/Header/index.module.css
@@ -6,46 +6,46 @@
 }
 
 .logo {
-  font-size: var(--font-size-heading-md);
+  font-size: var(--step-1);
   font-weight: bold;
   line-height: 1;
   position: fixed;
   top: 21px;
-  left: var(--spacing-xl);
+  left: var(--space-l);
   z-index: var(--z-index-header);
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1024px) /* sync with --bp-md */ {
   .logo {
-    left: var(--spacing-md);
+    left: var(--space-s);
   }
 }
 
 .nav {
   display: flex;
   align-items: center;
-  gap: var(--spacing-md);
+  gap: var(--space-s);
   position: fixed;
-  top: var(--spacing-md);
-  right: var(--spacing-xl);
+  top: var(--space-s);
+  right: var(--space-l);
   z-index: var(--z-index-header);
   font-weight: bold;
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1024px) /* sync with --bp-md */ {
   .nav {
-    gap: var(--spacing-xs);
-    top: var(--spacing-xs);
-    right: var(--spacing-md);
+    gap: var(--space-2xs);
+    top: var(--space-2xs);
+    right: var(--space-s);
   }
 }
 
 .navLinks {
   display: flex;
-  gap: var(--spacing-md);
+  gap: var(--space-s);
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1024px) /* sync with --bp-md */ {
   .navLinks {
     display: none;
   }
@@ -55,7 +55,7 @@
   display: none;
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1024px) /* sync with --bp-md */ {
   .hamburger {
     display: inline-flex;
   }
@@ -85,10 +85,10 @@
   content: "";
   display: block;
   width: 100%;
-  height: var(--spacing-xxs);
+  height: var(--space-3xs);
   background-color: var(--color-link);
   position: absolute;
-  bottom: calc(-1 * var(--spacing-xs));
+  bottom: calc(-1 * var(--space-2xs));
 }
 
 .spMenu {
@@ -107,23 +107,23 @@
   left: 0;
   right: 0;
   background-color: var(--color-background);
-  padding: var(--spacing-md);
+  padding: var(--space-s);
   z-index: var(--z-index-modal);
 }
 
 .close {
     position: fixed;
-    top: var(--spacing-xs);
-    right: var(--spacing-md);
+    top: var(--space-2xs);
+    right: var(--space-s);
   }
 
   .spNav {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xl);
+    gap: var(--space-l);
 
     a {
-      font-size: var(--font-size-heading-md);
+      font-size: var(--step-1);
       font-weight: bold;
       width: fit-content;
 

--- a/src/pages/_components/TopAboutMe.astro
+++ b/src/pages/_components/TopAboutMe.astro
@@ -29,11 +29,11 @@ import { LinkButton } from "../../ui/LinkButton";
 <style>
   .about {
     display: flex;
-    gap: var(--spacing-xxl);
+    gap: var(--space-2xl);
     justify-content: center;
     align-items: center;
 
-    @media screen and (max-width: 1000px) {
+    @media screen and (max-width: 1024px) /* sync with --bp-md */ {
       flex-direction: column;
     }
 
@@ -43,7 +43,7 @@ import { LinkButton } from "../../ui/LinkButton";
       display: flex;
       align-items: center;
       flex-direction: column;
-      gap: 48px;
+      gap: var(--space-xl);
       .monitor {
         width: 300px;
         height: 187.5px;
@@ -75,15 +75,11 @@ import { LinkButton } from "../../ui/LinkButton";
     .texts {
       display: flex;
       flex-direction: column;
-      gap: 48px;
-      max-width: 40rem;
+      gap: var(--space-xl);
+      max-width: var(--text-max-width);
       .title {
-        font-size: 4rem;
+        font-size: var(--step-5);
         font-weight: 900;
-
-        @media screen and (max-width: 1000px) {
-          font-size: var(--font-size-heading-xl);
-        }
       }
     }
   }

--- a/src/pages/_components/TopAnimation.astro
+++ b/src/pages/_components/TopAnimation.astro
@@ -115,13 +115,9 @@ import { AnimationIcon } from "../../features/AnimationIcon";
   }
 
   .title {
-    font-size: 96px;
+    font-size: var(--step-6);
     font-weight: 900;
-    margin-bottom: 48px;
-
-    @media screen and (max-width: 1000px) {
-      font-size: 40px;
-    }
+    margin-bottom: var(--space-xl);
   }
 
   .scroll {
@@ -138,7 +134,7 @@ import { AnimationIcon } from "../../features/AnimationIcon";
       top: 1.8rem;
       left: 50%;
       transform: translateX(-50%);
-      width: var(--spacing-xxxs);
+      width: var(--space-4xs);
       height: 36px;
       background: var(--color-text);
       animation: pathmove 1.5s ease-in-out infinite;
@@ -168,12 +164,12 @@ import { AnimationIcon } from "../../features/AnimationIcon";
 
   .animation-button {
     position: fixed;
-    bottom: var(--spacing-xl);
-    right: var(--spacing-xl);
+    bottom: var(--space-l);
+    right: var(--space-l);
 
-    @media screen and (max-width: 1000px) {
-      bottom: var(--spacing-md);
-      right: var(--spacing-md);
+    @media screen and (max-width: 1024px) /* sync with --bp-md */ {
+      bottom: var(--space-s);
+      right: var(--space-s);
     }
   }
 </style>

--- a/src/pages/_components/TopArticles.astro
+++ b/src/pages/_components/TopArticles.astro
@@ -33,32 +33,28 @@ const allPosts = await getAllPosts();
   .container {
     display: flex;
     flex-direction: column;
-    gap: 4rem;
+    gap: var(--space-2xl);
 
     .titles {
       display: flex;
       flex-wrap: wrap;
       flex-direction: row;
       align-items: end;
-      gap: 1.5rem;
+      gap: var(--space-m);
 
       .title {
-        font-size: 4rem;
+        font-size: var(--step-5);
         font-weight: 900;
         line-height: 1;
-
-        @media screen and (max-width: 1000px) {
-          font-size: var(--font-size-heading-xl);
-        }
       }
     }
 
     .articles {
       display: flex;
-      gap: 3rem;
+      gap: var(--space-xl);
       width: 100%;
 
-      @media screen and (max-width: 1000px) {
+      @media screen and (max-width: 1024px) /* sync with --bp-md */ {
         flex-direction: column;
       }
     }

--- a/src/pages/_components/TopProducts.astro
+++ b/src/pages/_components/TopProducts.astro
@@ -35,32 +35,28 @@ const productsCollection = (await getCollection("products")).sort((a, b) =>
   .container {
     display: flex;
     flex-direction: column;
-    gap: 4rem;
+    gap: var(--space-2xl);
 
     .titles {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
       align-items: end;
-      gap: 1.5rem;
+      gap: var(--space-m);
 
       .title {
-        font-size: 4rem;
+        font-size: var(--step-5);
         font-weight: 900;
         line-height: 1;
-
-        @media screen and (max-width: 1000px) {
-          font-size: var(--font-size-heading-xl);
-        }
       }
     }
 
     .products {
       display: flex;
-      gap: 3rem;
+      gap: var(--space-xl);
       width: 100%;
 
-      @media screen and (max-width: 1000px) {
+      @media screen and (max-width: 1024px) /* sync with --bp-md */ {
         flex-direction: column;
       }
     }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -78,69 +78,69 @@ import { Image } from "astro:assets";
       display: flex;
       flex-direction: column;
       align-items: center;
-      padding: 0rem var(--spacing-md);
+      padding: 0 var(--space-s);
       width: 100%;
     }
 
     .wrapper {
       display: flex;
       flex-direction: column;
-      max-width: 70rem;
+      max-width: 90rem;
       width: 100%;
       align-items: center;
-      padding-bottom: 96px;
+      padding-bottom: var(--space-3xl);
     }
 
     .section-2 {
-      width: fit-content;
+      width: 100%;
     }
 
     .title-flex {
-      margin-top: 3rem;
+      margin-top: var(--space-xl);
       display: flex;
       flex-direction: row;
-      gap: 0.5rem;
+      gap: var(--space-2xs);
       align-items: end;
     }
 
     .description {
       display: flex;
       flex-direction: column;
-      gap: 0.5rem;
-      margin-top: 0.5rem;
+      gap: var(--space-2xs);
+      margin-top: var(--space-2xs);
       width: 100%;
-      max-width: 40rem;
+      max-width: var(--text-max-width);
     }
     .h2 {
-      margin-top: 4rem;
-      font-size: var(--font-size-heading-xl);
+      margin-top: var(--space-2xl);
+      font-size: var(--step-2);
       font-weight: 900;
     }
 
     .h3 {
-      font-size: var(--font-size-heading-md);
+      font-size: var(--step-1);
       font-weight: 900;
     }
 
     .section-flex {
       display: flex;
-      gap: 2rem;
+      gap: var(--space-l);
       width: 100%;
 
-      @media screen and (max-width: 40rem) {
+      @media screen and (max-width: 40rem) /* sync with --bp-sm */ {
         flex-direction: column;
-        gap: 1rem;
+        gap: var(--space-s);
         align-items: center;
       }
     }
 
     .image-wrapper {
-      width: 400px;
-      flex-shrink: 0;
+      flex: 1;
+      min-width: 0;
       position: relative;
       aspect-ratio: 8/5;
 
-      @media screen and (max-width: 40rem) {
+      @media screen and (max-width: 40rem) /* sync with --bp-sm */ {
         width: 100%;
       }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,12 +38,12 @@ import TopArticles from "./_components/TopArticles.astro";
       display: flex;
       justify-content: center;
       .main {
-        padding: 48px var(--spacing-md) 96px var(--spacing-md);
+        padding: var(--space-xl) var(--space-s) var(--space-3xl) var(--space-s);
         overflow: hidden;
         display: flex;
         flex-direction: column;
-        gap: 5rem;
-        max-width: 70rem;
+        gap: var(--space-2xl);
+        max-width: 90rem;
       }
     }
   }

--- a/src/pages/posts.astro
+++ b/src/pages/posts.astro
@@ -35,22 +35,22 @@ const allPosts = await getAllPosts();
   .container {
     display: flex;
     flex-direction: column;
-    padding: 0 var(--spacing-md);
+    padding: 0 var(--space-s);
     align-items: center;
     .articles {
-      padding-top: var(--spacing-xxl);
-      padding-bottom: 96px;
+      padding-top: var(--space-2xl);
+      padding-bottom: var(--space-3xl);
       display: grid;
       grid-template-columns: repeat(3, 1fr);
-      gap: var(--spacing-xxl) 48px;
+      gap: var(--space-2xl) var(--space-xl);
       list-style: none;
-      max-width: 70rem;
+      max-width: 90rem;
       width: 100%;
 
-      @media screen and (max-width: 1000px) {
+      @media screen and (max-width: 1024px) /* sync with --bp-md */ {
         display: flex;
         flex-direction: column;
-        gap: 2rem;
+        gap: var(--space-l);
       }
     }
   }

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -85,9 +85,9 @@ import CommonHead from "../../components/CommonHead.astro";
     <style>
       .container {
         width: 100%;
-        max-width: calc(70rem + 2rem);
+        max-width: 90rem;
         margin: 0 auto;
-        padding: 96px var(--spacing-md);
+        padding: var(--space-3xl) var(--space-s);
       }
     </style>
   </body>

--- a/src/pages/posts/_components/BlogPost/TableOfContents.astro
+++ b/src/pages/posts/_components/BlogPost/TableOfContents.astro
@@ -29,12 +29,12 @@ const { headings } = Astro.props;
   /* 目次スタイル */
   .toc {
     grid-area: toc;
-    padding: 1.5rem;
+    padding: var(--space-m);
     background-color: var(--color-white);
-    border-radius: 0.5rem;
+    border-radius: var(--radius-md);
 
     /* PC: 右サイドバー固定 */
-    @media screen and (min-width: 1001px) {
+    @media screen and (min-width: 1025px) /* sync with --bp-md-plus */ {
       position: sticky;
       top: 2rem;
       max-height: calc(100vh - 4rem);
@@ -42,15 +42,15 @@ const { headings } = Astro.props;
     }
 
     .toc-title {
-      font-size: var(--font-size-heading-sm);
+      font-size: var(--step-0);
       font-weight: 700;
-      margin-bottom: 1rem;
+      margin-bottom: var(--space-s);
     }
 
     .toc-list {
       display: flex;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: var(--space-2xs);
       list-style: none;
       padding: 0;
     }
@@ -60,8 +60,8 @@ const { headings } = Astro.props;
         display: inline-block;
         color: var(--color-link);
         text-decoration: none;
-        padding: 0.25rem 0.5rem;
-        border-radius: 0.25rem;
+        padding: var(--space-3xs) var(--space-2xs);
+        border-radius: var(--radius-sm);
         transition: background-color 0.2s;
         line-height: 1.5;
         text-decoration: underline;
@@ -74,15 +74,15 @@ const { headings } = Astro.props;
 
     /* 階層インデント */
     .toc-depth-2 a {
-      margin-left: 0.5rem;
+      margin-left: var(--space-2xs);
     }
 
     .toc-depth-3 a {
-      margin-left: 1.5rem;
+      margin-left: var(--space-m);
     }
 
     .toc-depth-4 a {
-      margin-left: 2.5rem;
+      margin-left: var(--space-l);
     }
   }
 </style>

--- a/src/pages/posts/_components/BlogPost/content.css
+++ b/src/pages/posts/_components/BlogPost/content.css
@@ -2,13 +2,13 @@
   grid-area: content;
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-md);
+  gap: var(--space-s);
   width: 100%;
 
   /* pc */
-  @media screen and (min-width: 1001px) {
+  @media screen and (min-width: 1025px) /* sync with --bp-md-plus */ {
     background-color: var(--color-white);
-    padding: 2rem;
+    padding: var(--space-l);
     border-radius: var(--radius-md);
   }
 
@@ -18,8 +18,8 @@
     overflow: hidden;
 
     :global(section) {
-      margin-bottom: 2rem;
-      padding: 2rem;
+      margin-bottom: var(--space-l);
+      padding: var(--space-l);
       background: var(--color-background);
       border: 1px solid var(--color-text);
       border-radius: var(--radius-md);
@@ -27,37 +27,37 @@
     }
 
     :global(h1) {
-      font-size: var(--font-size-title-md);
+      font-size: var(--step-3);
       font-weight: 900;
-      margin-bottom: 1rem;
+      margin-bottom: var(--space-s);
       color: var(--color-link);
     }
 
     :global(h2) {
-      font-size: var(--font-size-heading-xl);
+      font-size: var(--step-2);
       font-weight: 700;
-      margin-bottom: 1rem;
+      margin-bottom: var(--space-s);
     }
 
     :global(h3) {
-      font-size: var(--font-size-heading-md);
+      font-size: var(--step-0);
       font-weight: 600;
-      margin-bottom: 0.5rem;
+      margin-bottom: var(--space-2xs);
     }
 
     :global(ul) {
-      margin: 1rem 0;
-      padding-left: 2rem;
+      margin: var(--space-s) 0;
+      padding-left: var(--space-l);
     }
 
     :global(li) {
-      margin-bottom: 0.5rem;
+      margin-bottom: var(--space-2xs);
     }
 
     :global(code) {
       background-color: var(--color-text);
       color: var(--color-background);
-      padding: 0.25rem 0.5rem;
+      padding: var(--space-3xs) var(--space-2xs);
       border-radius: var(--radius-sm);
       font-family: "Courier New", monospace;
     }
@@ -65,10 +65,10 @@
     :global(pre) {
       background-color: var(--color-text);
       color: var(--color-background);
-      padding: 1rem;
+      padding: var(--space-s);
       border-radius: var(--radius-md);
       overflow-x: auto;
-      margin: 1rem 0;
+      margin: var(--space-s) 0;
     }
 
     :global(pre code) {
@@ -78,20 +78,20 @@
   }
 
   h2 {
-    margin-top: 2rem;
-    font-size: var(--font-size-heading-xl);
+    margin-top: var(--space-l);
+    font-size: var(--step-2);
     font-weight: 900;
   }
 
   h3 {
-    margin-top: 1rem;
-    font-size: var(--font-size-heading-md);
+    margin-top: var(--space-s);
+    font-size: var(--step-1);
     font-weight: 900;
   }
 
   h4 {
-    margin-top: 0.5rem;
-    font-size: var(--font-size-heading-sm);
+    margin-top: var(--space-2xs);
+    font-size: var(--step-1);
     font-weight: 900;
   }
 
@@ -103,26 +103,26 @@
   ul {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs);
-    padding-left: 1.5rem;
+    gap: var(--space-2xs);
+    padding-left: var(--space-m);
 
     li {
       /* 点をつける */
       list-style: disc;
-      padding-left: 0.5rem;
+      padding-left: var(--space-2xs);
     }
   }
 
   ol {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs);
-    padding-left: 1.5rem;
+    gap: var(--space-2xs);
+    padding-left: var(--space-m);
 
     li {
       /* 番号をつける */
       list-style: decimal;
-      padding-left: 0.5rem;
+      padding-left: var(--space-2xs);
     }
   }
 
@@ -133,12 +133,12 @@
 
   em {
     font-style: normal;
-    font-size: var(--font-size-body-sm);
+    font-size: var(--step--1);
   }
 
   th,
   td {
-    padding: 0.5rem;
+    padding: var(--space-2xs);
     border: 1px solid var(--color-text);
   }
 
@@ -151,14 +151,14 @@
   :not(pre) > code {
     background-color: var(--color-text);
     color: var(--color-background);
-    padding: 0.25rem 0.5rem;
+    padding: var(--space-3xs) var(--space-2xs);
     border-radius: var(--radius-sm);
-    margin: 0 0.25rem;
-    font-size: var(--font-size-body-sm);
+    margin: 0 var(--space-3xs);
+    font-size: var(--step--1);
   }
 
   pre {
-    padding: 1rem;
+    padding: var(--space-s);
   }
 }
 

--- a/src/pages/posts/_components/BlogPost/index.astro
+++ b/src/pages/posts/_components/BlogPost/index.astro
@@ -54,10 +54,10 @@ const { post, Content, headings } = Astro.props;
 <style>
   .wrapper {
     display: grid;
-    gap: 2rem;
+    gap: var(--space-l);
     width: 100%;
     margin: 0 auto;
-    padding-top: 2rem;
+    padding-top: var(--space-l);
     align-items: start;
 
     /* SP: 縦1列 (title -> toc -> content) */
@@ -66,17 +66,16 @@ const { post, Content, headings } = Astro.props;
       "title"
       "toc"
       "content";
-    max-width: 40rem;
+    max-width: var(--text-max-width);
 
-    /* PC: 2カラム (title が上に跨ぐ, content左 + toc右) */
-    @media screen and (min-width: 1001px) {
-      grid-template-columns: 1fr 280px;
+    /* PC: 2カラム (title が上に跨ぐ, content左 + toc右)
+       wrapper max は: text-max-width + (content padding * 2 + grid gap) * space-l + TOC */
+    @media screen and (min-width: 1025px) /* sync with --bp-md-plus */ {
+      grid-template-columns: 1fr 360px;
       grid-template-areas:
         "title title"
         "content toc";
-      max-width: calc(
-        44rem + 280px + 2rem
-      ); /* 44rem = 40rem + 2rem (padding) */
+      max-width: calc(var(--text-max-width) + var(--space-l) * 3 + 360px);
     }
 
     .title-wrapper {
@@ -84,28 +83,28 @@ const { post, Content, headings } = Astro.props;
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 1rem;
+      gap: var(--space-s);
       width: 100%;
-      max-width: 40rem;
+      max-width: var(--text-max-width);
       margin: 0 auto;
 
       .post-meta {
         display: flex;
         align-items: center;
-        gap: 1rem;
+        gap: var(--space-s);
       }
 
       .slide-badge {
         background-color: var(--color-link);
         color: var(--color-background);
-        padding: 0.25rem 0.5rem;
-        border-radius: 0.25rem;
-        font-size: var(--font-size-body-sm);
+        padding: var(--space-3xs) var(--space-2xs);
+        border-radius: var(--radius-sm);
+        font-size: var(--step--1);
         font-weight: bold;
       }
 
       .title {
-        font-size: var(--font-size-heading-xl);
+        font-size: var(--step-2);
         font-weight: 900;
       }
 
@@ -115,7 +114,7 @@ const { post, Content, headings } = Astro.props;
         aspect-ratio: 720 / 378;
         object-fit: cover;
         border: 8px solid var(--color-white);
-        border-radius: 0.5rem;
+        border-radius: var(--radius-md);
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
       }
     }

--- a/src/pages/posts/_components/Comments.astro
+++ b/src/pages/posts/_components/Comments.astro
@@ -55,13 +55,13 @@
 <style>
   .comments {
     width: 100%;
-    max-width: 40rem;
-    margin: 4rem auto 0;
+    max-width: var(--text-max-width);
+    margin: var(--space-2xl) auto 0;
   }
 
   .heading {
-    font-size: var(--font-size-heading-md);
+    font-size: var(--step-1);
     font-weight: 700;
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--space-m);
   }
 </style>

--- a/src/pages/posts/_components/SlideControls.module.css
+++ b/src/pages/posts/_components/SlideControls.module.css
@@ -1,19 +1,19 @@
 .controls {
   position: fixed;
-  bottom: var(--spacing-lg);
+  bottom: var(--space-m);
   left: 50%;
   transform: translateX(-50%);
   z-index: var(--z-index-toast);
   display: flex;
   align-items: center;
-  gap: var(--spacing-xs);
+  gap: var(--space-2xs);
   background-color: rgba(4, 27, 71, 0.78);
   color: var(--color-white);
-  padding: var(--spacing-xs) 14px;
+  padding: var(--space-2xs) var(--space-xs);
   border-radius: var(--radius-infinity);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18); /* stylelint-disable-line scale-unlimited/declaration-strict-value */
+  box-shadow: var(--shadow-elevation-4);
 }
 
 .btn {
@@ -25,7 +25,7 @@
   border-radius: 50%;
   background-color: rgba(255, 255, 255, 0.16);
   color: var(--color-white);
-  font-size: 1.1rem; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
+  font-size: var(--step-0);
   border: none;
   cursor: pointer;
   transition: background-color 0.15s ease;
@@ -37,7 +37,7 @@
 
 .btn:focus-visible {
   outline: var(--border-width-lg) solid var(--color-white);
-  outline-offset: var(--spacing-xxxs);
+  outline-offset: var(--space-4xs);
 }
 
 .btn:disabled {
@@ -46,7 +46,7 @@
 }
 
 .indicator {
-  font-size: var(--font-size-body-sm);
+  font-size: var(--step--1);
   font-weight: 700;
   min-width: 56px;
   text-align: center;

--- a/src/pages/posts/_components/SlidePost.astro
+++ b/src/pages/posts/_components/SlidePost.astro
@@ -45,7 +45,7 @@ const totalSlides = result.comments.length;
   .slide-container {
     width: 100%;
     max-width: calc(70rem + 2rem);
-    margin-top: 2rem;
+    margin-top: var(--space-l);
     margin-right: auto;
     margin-left: auto;
 
@@ -53,7 +53,7 @@ const totalSlides = result.comments.length;
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 1rem;
+      gap: var(--space-s);
       width: 100%;
       max-width: 100%;
       margin: 0 auto;

--- a/src/pages/products.astro
+++ b/src/pages/products.astro
@@ -37,30 +37,30 @@ const productsCollection = (await getCollection("products")).sort((a, b) =>
       display: flex;
       flex-direction: column;
       align-items: center;
-      padding: 0rem var(--spacing-md);
+      padding: 0 var(--space-s);
 
       .products {
         /* grid 2つ並べて折り返す*/
         display: grid;
         grid-template-columns: repeat(2, 1fr);
-        max-width: 70rem;
-        padding-top: var(--spacing-xxl);
-        padding-bottom: 96px;
+        max-width: 90rem;
+        padding-top: var(--space-2xl);
+        padding-bottom: var(--space-3xl);
         width: 100%;
 
         > *:nth-child(odd) {
-          padding: var(--spacing-xl) var(--spacing-lg) var(--spacing-xxl) 0;
+          padding: var(--space-l) var(--space-m) var(--space-2xl) 0;
         }
 
         > *:nth-child(even) {
-          padding: 96px 0 0 var(--spacing-lg);
+          padding: var(--space-3xl) 0 0 var(--space-m);
         }
 
-        @media screen and (max-width: 1000px) {
+        @media screen and (max-width: 1024px) /* sync with --bp-md */ {
           display: flex;
           flex-direction: column;
-          gap: 2rem;
-          padding-bottom: 6rem;
+          gap: var(--space-l);
+          padding-bottom: var(--space-3xl);
 
           > *:nth-child(odd) {
             padding: 0;

--- a/src/pages/products/[slug].astro
+++ b/src/pages/products/[slug].astro
@@ -62,22 +62,22 @@ import CommonHead from "../../components/CommonHead.astro";
     <style>
       .container {
         width: 100%;
-        max-width: calc(50rem + 2rem);
+        max-width: 90rem;
         margin: 0 auto;
-        padding: 96px var(--spacing-md);
+        padding: var(--space-3xl) var(--space-s);
       }
       .breadcrumbs {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        gap: 0.5rem;
-        padding: 0.5rem 1rem;
+        gap: var(--space-2xs);
+        padding: var(--space-2xs) var(--space-s);
         background-color: var(--color-white);
         height: fit-content;
         width: fit-content;
         border-radius: var(--radius-infinity);
 
-        @media screen and (max-width: 1000px) {
+        @media screen and (max-width: 1024px) /* sync with --bp-md */ {
           width: 100%;
         }
 

--- a/src/pages/products/_components/ProductPost/index.astro
+++ b/src/pages/products/_components/ProductPost/index.astro
@@ -79,34 +79,39 @@ const { product, Content } = Astro.props;
   .wrapper {
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: var(--space-l);
     width: 100%;
-    max-width: 40rem;
+    max-width: var(--text-max-width);
     margin: 0 auto;
-    padding-top: 2rem;
+    padding-top: var(--space-l);
+
+    /* PC では content.css の padding 分（space-l * 2）を加味して text 領域が text-max-width に届くようにする */
+    @media screen and (min-width: 1025px) /* sync with --bp-md-plus */ {
+      max-width: calc(var(--text-max-width) + var(--space-l) * 2);
+    }
   }
 
   .title-wrapper {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1rem;
+    gap: var(--space-s);
     width: 100%;
 
     .post-meta {
-      font-size: var(--font-size-body-sm);
+      font-size: var(--step--1);
       color: var(--color-text);
       opacity: 0.6;
     }
 
     .title {
-      font-size: var(--font-size-heading-xl);
+      font-size: var(--step-2);
       font-weight: 900;
       text-align: center;
     }
 
     .description {
-      font-size: 1rem;
+      font-size: var(--step-0);
       text-align: center;
     }
   }
@@ -120,14 +125,14 @@ const { product, Content } = Astro.props;
       aspect-ratio: 720 / 450;
       object-fit: cover;
       border: 8px solid var(--color-white);
-      border-radius: 0.5rem;
+      border-radius: var(--radius-md);
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     }
   }
 
   .links {
     display: flex;
-    gap: 1rem;
+    gap: var(--space-s);
     flex-wrap: wrap;
     justify-content: center;
   }
@@ -135,8 +140,8 @@ const { product, Content } = Astro.props;
   .link-button {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem;
+    gap: var(--space-2xs);
+    padding: var(--space-xs) var(--space-s);
     border: solid 1px var(--color-text);
     border-radius: var(--radius-infinity);
     text-decoration: none;
@@ -152,15 +157,15 @@ const { product, Content } = Astro.props;
 
   .tech-stack {
     display: flex;
-    gap: 0.5rem;
+    gap: var(--space-2xs);
     flex-wrap: wrap;
     justify-content: center;
   }
 
   .tech-badge {
-    padding: 0.25rem 0.75rem;
+    padding: var(--space-3xs) var(--space-xs);
     background-color: var(--color-white);
     border-radius: var(--radius-infinity);
-    font-size: var(--font-size-label-sm);
+    font-size: var(--step--1);
   }
 </style>

--- a/src/pages/siteMap.astro
+++ b/src/pages/siteMap.astro
@@ -34,17 +34,17 @@ const allPosts = await getCollection("posts");
   .container {
     display: flex;
     flex-direction: column;
-    padding: 0 var(--spacing-md);
+    padding: 0 var(--space-s);
     align-items: center;
     .links {
-      padding-top: var(--spacing-xxl);
-      padding-bottom: 96px;
+      padding-top: var(--space-2xl);
+      padding-bottom: var(--space-3xl);
       width: 100%;
-      max-width: 70rem;
+      max-width: 90rem;
       display: flex;
       flex-direction: column;
-      gap: 1rem;
-      padding-left: 1.5rem;
+      gap: var(--space-s);
+      padding-left: var(--space-m);
 
       li {
         list-style: disc;
@@ -53,10 +53,10 @@ const allPosts = await getCollection("posts");
       }
 
       .childLinks {
-        padding-left: 1.5rem;
+        padding-left: var(--space-m);
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
+        gap: var(--space-2xs);
       }
     }
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,66 +5,61 @@
   --color-blue: #84c5ea;
   --color-link: #023aa2;
 
-  /* Font Sizes - Title */
-  --font-size-title-lg: 3rem;
-  --font-size-title-lg--line-height: 1.5;
-  --font-size-title-lg--letter-spacing: 0.01em;
-  --font-size-title-md: 2.5rem;
-  --font-size-title-md--line-height: 1.5;
-  --font-size-title-md--letter-spacing: 0.02em;
+  /* Fluid Type Scale (Utopia.fyi)
+     Min viewport: 320px / Min font: 16px / Min scale: 1.2 (Minor Third)
+     Max viewport: 1440px / Max font: 20px / Max scale: 1.25 (Major Third) */
+  --step--2: clamp(0.6944rem, 0.6642rem + 0.1508vw, 0.8rem);
+  --step--1: clamp(0.8333rem, 0.7857rem + 0.2381vw, 1rem);
+  --step-0: clamp(1rem, 0.9286rem + 0.3571vw, 1.25rem);
+  --step-1: clamp(1.2rem, 1.0964rem + 0.5179vw, 1.5625rem);
+  --step-2: clamp(1.44rem, 1.2934rem + 0.733vw, 1.9531rem);
+  --step-3: clamp(1.728rem, 1.5242rem + 1.0192vw, 2.4414rem);
+  --step-4: clamp(2.0736rem, 1.7941rem + 1.3974vw, 3.0518rem);
+  --step-5: clamp(2.4883rem, 2.1093rem + 1.8949vw, 3.8147rem);
+  /* step-6 はカスタム値（hero 専用、PageTitle SP の現状 32px を維持） */
+  --step-6: clamp(2rem, 0.8571rem + 5.7143vw, 6rem);
 
-  /* Font Sizes - Heading */
-  --font-size-heading-xl: 2rem;
-  --font-size-heading-xl--line-height: 1.53;
-  --font-size-heading-xl--letter-spacing: 0.02em;
-  --font-size-heading-lg: 1.75rem;
-  --font-size-heading-lg--line-height: 1.57;
-  --font-size-heading-lg--letter-spacing: 0.02em;
-  --font-size-heading-md: 1.5rem;
-  --font-size-heading-md--line-height: 1.67;
-  --font-size-heading-md--letter-spacing: 0.03em;
-  --font-size-heading-sm: 1.25rem;
-  --font-size-heading-sm--line-height: 1.6;
-  --font-size-heading-sm--letter-spacing: 0.03em;
-  --font-size-heading-xs: 1rem;
-  --font-size-heading-xs--line-height: 1.75;
-  --font-size-heading-xs--letter-spacing: 0.03em;
+  /* Line-height (用途別) */
+  --leading-tight: 1;
+  --leading-snug: 1.5;
+  --leading-relaxed: 1.6;
+  --leading-loose: 1.75;
+  --leading-paragraph: 2;
 
-  /* Font Sizes - Body */
-  --font-size-body-lg: 1.25rem;
-  --font-size-body-lg--line-height: 1.6;
-  --font-size-body-lg--letter-spacing: 0.03em;
-  --font-size-body-md: 1rem;
-  --font-size-body-md--line-height: 1.75;
-  --font-size-body-md--letter-spacing: 0.03em;
-  --font-size-body-sm: 0.875rem;
-  --font-size-body-sm--line-height: 1.71;
-  --font-size-body-sm--letter-spacing: 0.03em;
-  --font-size-body-xs: 0.75rem;
-  --font-size-body-xs--line-height: 1.67;
-  --font-size-body-xs--letter-spacing: 0.04em;
+  /* Letter-spacing (用途別) */
+  --tracking-tight: 0.01em;
+  --tracking-normal: 0.02em;
+  --tracking-wide: 0.03em;
+  --tracking-wider: 0.04em;
 
-  /* Font Sizes - Label */
-  --font-size-label-md: 1rem;
-  --font-size-label-md--line-height: 1;
-  --font-size-label-md--letter-spacing: 0.03em;
-  --font-size-label-sm: 0.875rem;
-  --font-size-label-sm--line-height: 1;
-  --font-size-label-sm--letter-spacing: 0.03em;
-  --font-size-label-xs: 0.75rem;
-  --font-size-label-xs--line-height: 1;
-  --font-size-label-xs--letter-spacing: 0.04em;
+  /* Fluid Space Scale (Utopia.fyi)
+     Base: step-0 = 16→20px。標準 T-shirt サイズ + 拡張 4xs (2→2.5px) */
+  --space-4xs: clamp(0.125rem, 0.1161rem + 0.0446vw, 0.1563rem);
+  --space-3xs: clamp(0.25rem, 0.2321rem + 0.0893vw, 0.3125rem);
+  --space-2xs: clamp(0.5rem, 0.4643rem + 0.1786vw, 0.625rem);
+  --space-xs: clamp(0.75rem, 0.6964rem + 0.2679vw, 0.9375rem);
+  --space-s: clamp(1rem, 0.9286rem + 0.3571vw, 1.25rem);
+  --space-m: clamp(1.5rem, 1.3929rem + 0.5357vw, 1.875rem);
+  --space-l: clamp(2rem, 1.8571rem + 0.7143vw, 2.5rem);
+  --space-xl: clamp(3rem, 2.7857rem + 1.0714vw, 3.75rem);
+  --space-2xl: clamp(4rem, 3.7143rem + 1.4286vw, 5rem);
+  --space-3xl: clamp(6rem, 5.5714rem + 2.1429vw, 7.5rem);
 
-  /* Spacing */
-  --spacing-none: 0px;
-  --spacing-xxxs: 2px;
-  --spacing-xxs: 4px;
-  --spacing-xs: 8px;
-  --spacing-sm: 12px;
-  --spacing-md: 16px;
-  --spacing-lg: 24px;
-  --spacing-xl: 32px;
-  --spacing-xxl: 64px;
+  /* Space Pairs (小ビューポートで小側、大ビューポートで大側に開く動的スペース) */
+  --space-s-m: clamp(1rem, 0.75rem + 1.25vw, 1.875rem);
+  --space-m-l: clamp(1.5rem, 1.2143rem + 1.4286vw, 2.5rem);
+  --space-l-xl: clamp(2rem, 1.5rem + 2.5vw, 3.75rem);
+
+  /* Breakpoints
+     値の管理のみ。@media クエリ内はリテラル値を残し、`sync with --bp-*` コメントで同期させる */
+  --bp-sm: 40rem;
+  --bp-md: 64rem;
+  --bp-md-plus: 64.0625rem;
+
+  /* Text measure (本文の読みやすい行長)
+     全角 40 文字を基準に body font-size (step-0 = 16→20px) に合わせて fluid 化
+     320px viewport: 40rem (= 16px × 40字)、1440px viewport: 50rem (= 20px × 40字) */
+  --text-max-width: clamp(40rem, 37.1429rem + 14.2857vw, 50rem);
 
   /* Border Radius */
   --radius-none: 0px;
@@ -119,28 +114,29 @@ html {
     "Hiragino Sans",
     Meiryo,
     sans-serif;
-  font-size: 1rem; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
-  line-height: 1.5;
+  font-size: 100%;
+  line-height: var(--leading-snug);
 
   body {
     min-height: 100vh;
     display: flex;
     flex-direction: column;
+    font-size: var(--step-0);
   }
-  
+
   footer {
     margin-top: auto;
   }
 
   p {
-    line-height: 2;
-    max-width: 40rem;
+    line-height: var(--leading-paragraph);
+    max-width: var(--text-max-width);
   }
 
   p br {
     content: "";
     display: block;
-    margin-bottom: 1rem;
+    margin-bottom: var(--space-s);
   }
 }
 

--- a/src/ui/BlogPost/index.module.css
+++ b/src/ui/BlogPost/index.module.css
@@ -4,7 +4,7 @@
 .link {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-md);
+  gap: var(--space-s);
   width: 100%;
 }
 .mask {
@@ -24,30 +24,30 @@
 .texts {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-xs);
+  gap: var(--space-2xs);
 }
 .meta {
   display: flex;
   align-items: center;
-  gap: var(--spacing-xs);
-  font-size: var(--font-size-body-sm);
+  gap: var(--space-2xs);
+  font-size: var(--step--1);
 }
 .slideBadge {
   background-color: var(--color-link);
   color: var(--color-background);
-  padding: 0.25rem 0.5rem;
+  padding: var(--space-3xs) var(--space-2xs);
   border-radius: var(--radius-sm);
-  font-size: var(--font-size-body-xs);
+  font-size: var(--step--2);
   font-weight: bold;
 }
 .title {
-  font-size: 1.125rem; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
+  font-size: var(--step-0);
   font-weight: 700;
 }
 .icon {
   display: inline;
   vertical-align: -0.125em;
-  margin-left: var(--spacing-xxxs);
+  margin-left: var(--space-4xs);
 }
 .link:hover .image {
   transform: scale(1.1);

--- a/src/ui/Breadcrumb/index.module.css
+++ b/src/ui/Breadcrumb/index.module.css
@@ -1,5 +1,5 @@
 .breadcrumbs {
-  padding: 0.5rem 1rem;
+  padding: var(--space-2xs) var(--space-s);
   background-color: var(--color-white);
   height: fit-content;
   width: fit-content;
@@ -9,7 +9,7 @@
 }
 
 /* TODO: コンポーネントが画面を気にしているのが気持ち悪いため見直す。 */
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1024px) /* sync with --bp-md */ {
   .breadcrumbs {
     width: 100%;
   }
@@ -20,7 +20,7 @@
 }
 
 .item:not(:last-child) {
-  margin-right: 0.5rem;
+  margin-right: var(--space-2xs);
 }
 
 .item a {
@@ -30,5 +30,5 @@
 
 .item svg {
   vertical-align: middle;
-  margin-left: 0.5rem;
+  margin-left: var(--space-2xs);
 }

--- a/src/ui/LinkButton/index.module.css
+++ b/src/ui/LinkButton/index.module.css
@@ -1,5 +1,5 @@
 .button {
-  padding: 0.75rem 1rem;
+  padding: var(--space-xs) var(--space-s);
   border: solid 1px var(--color-text);
   color: var(--color-text);
   background-color: var(--color-white);

--- a/src/ui/PageTitle/index.module.css
+++ b/src/ui/PageTitle/index.module.css
@@ -3,19 +3,19 @@
   width: 100%;
   display: flex;
   justify-content: center;
-  margin-top: 6rem;
+  margin-top: var(--space-3xl);
 }
 .wrapper {
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  max-width: 70rem;
+  max-width: 90rem;
 }
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1024px) /* sync with --bp-md */ {
   .wrapper {
     flex-direction: column;
-    gap: var(--spacing-xl);
+    gap: var(--space-l);
     align-items: flex-start;
   }
 }
@@ -24,17 +24,12 @@
   z-index: 1;
 }
 .title {
-  font-size: 96px; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
+  font-size: var(--step-6);
   font-weight: 700;
   line-height: 1;
   background-color: var(--color-background);
   position: relative;
   z-index: 1;
-}
-@media screen and (max-width: 1000px) {
-  .title {
-    font-size: var(--font-size-heading-xl);
-  }
 }
 .line {
   position: absolute;
@@ -43,7 +38,7 @@
   background-color: var(--color-text);
   bottom: 20%;
 }
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1024px) /* sync with --bp-md */ {
   .line {
     visibility: hidden;
   }

--- a/src/ui/ProductItem/index.module.css
+++ b/src/ui/ProductItem/index.module.css
@@ -4,16 +4,16 @@
   flex-direction: column;
   align-items: end;
   justify-content: center;
-  gap: var(--spacing-lg);
+  gap: var(--space-m);
 }
 .index-parent {
   position: relative;
-  padding-left: 48px;
+  padding-left: var(--space-xl);
   width: 100%;
   height: auto;
 }
 .index {
-  font-size: 96px; /* stylelint-disable-line scale-unlimited/declaration-strict-value */
+  font-size: var(--step-6);
   font-weight: 700;
   position: absolute;
   bottom: -64px;
@@ -39,13 +39,13 @@
   display: flex;
   flex-direction: column;
   align-items: end;
-  gap: var(--spacing-md);
+  gap: var(--space-s);
   text-align: right;
 }
 .link {
   text-decoration: none;
   color: inherit;
-  font-size: var(--font-size-heading-md);
+  font-size: var(--step-1);
   font-weight: 700;
 }
 .product:hover .image {


### PR DESCRIPTION
## What

サイト全体のフォントと余白を Utopia.fyi 流の Fluid Type / Fluid Space で組み直した。

## Why

これまでは `font-size: 1rem` / `spacing-md: 16px` のような静的トークンで、SP と PC でメディアクエリを使って切り替える運用だった。これに以下の課題があった:

- **中間ビューポートが置き去り**: 768〜1024px のように「SP でも PC でもない」幅で、固定値が中途半端に見える
- **SP 専用の font-size 切替が散在**: PageTitle / TopAnimation など、要素ごとに `@media` で別サイズを当てる必要があった
- **大画面でも本文 16px のまま**: 1440px 級のディスプレイでは小さすぎる。

Utopia の `clamp()` ベースの fluid 設計に切り替えることで、ビューポート幅に対して滑らかに型・余白が育つようになり、上記の歪みをまとめて解消できる。

## Refs

https://utopia.fyi/blog/designing-with-fluid-type-scales