### PR TITLE
semantic colorを定義

### DIFF
--- a/src/features/Footer/index.module.css
+++ b/src/features/Footer/index.module.css
@@ -1,5 +1,5 @@
 .footer {
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/marp-themes/custom-theme.css
+++ b/src/marp-themes/custom-theme.css
@@ -21,7 +21,7 @@ section {
 
 /* タイトルスライド */
 section.title {
-  background-color: var(--color-blue);
+  background-color: var(--color-accent);
   position: relative;
   align-items: flex-start;
   justify-content: center;
@@ -70,7 +70,7 @@ section.title p {
 
 /* 強調用スライド */
 section.strong {
-  background-color: var(--color-blue);
+  background-color: var(--color-accent);
   position: relative;
   padding: 4.5rem;
   display: flex;

--- a/src/pages/_components/TopAboutMe.astro
+++ b/src/pages/_components/TopAboutMe.astro
@@ -47,16 +47,16 @@ import { LinkButton } from "../../ui/LinkButton";
       .monitor {
         width: 300px;
         height: 187.5px;
-        background-color: var(--color-white);
+        background-color: var(--color-surface);
         border-radius: var(--radius-xl);
-        border: 8px solid var(--color-white);
+        border: 8px solid var(--color-surface);
         position: relative;
 
         .screen {
           position: absolute;
           top: 0;
           left: 0;
-          background-color: var(--color-white);
+          background-color: var(--color-surface);
           width: 100%;
           height: 100%;
           object-fit: cover;
@@ -66,7 +66,7 @@ import { LinkButton } from "../../ui/LinkButton";
 
       .keyboard {
         width: 150px;
-        border-bottom: 30px solid var(--color-white);
+        border-bottom: 30px solid var(--color-surface);
         border-left: 8px solid transparent;
         border-right: 8px solid transparent;
       }

--- a/src/pages/_components/TopAnimation.astro
+++ b/src/pages/_components/TopAnimation.astro
@@ -74,7 +74,7 @@ import { AnimationIcon } from "../../features/AnimationIcon";
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: var(--color-blue);
+    background-color: var(--color-accent);
     position: relative;
   }
 
@@ -136,7 +136,7 @@ import { AnimationIcon } from "../../features/AnimationIcon";
       transform: translateX(-50%);
       width: var(--space-4xs);
       height: 36px;
-      background: var(--color-text);
+      background: var(--color-border);
       animation: pathmove 1.5s ease-in-out infinite;
       opacity: 1;
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,7 +28,7 @@ import TopArticles from "./_components/TopArticles.astro";
     display: flex;
     flex-direction: column;
     align-items: center;
-    background-color: var(--color-blue);
+    background-color: var(--color-accent);
 
     .background {
       margin-top: 50vh;

--- a/src/pages/posts/_components/BlogPost/TableOfContents.astro
+++ b/src/pages/posts/_components/BlogPost/TableOfContents.astro
@@ -30,7 +30,7 @@ const { headings } = Astro.props;
   .toc {
     grid-area: toc;
     padding: var(--space-m);
-    background-color: var(--color-white);
+    background-color: var(--color-surface);
     border-radius: var(--radius-md);
 
     /* PC: 右サイドバー固定 */

--- a/src/pages/posts/_components/BlogPost/content.css
+++ b/src/pages/posts/_components/BlogPost/content.css
@@ -7,7 +7,7 @@
 
   /* pc */
   @media screen and (min-width: 1025px) /* sync with --bp-md-plus */ {
-    background-color: var(--color-white);
+    background-color: var(--color-surface);
     padding: var(--space-l);
     border-radius: var(--radius-md);
   }
@@ -21,7 +21,7 @@
       margin-bottom: var(--space-l);
       padding: var(--space-l);
       background: var(--color-background);
-      border: 1px solid var(--color-text);
+      border: 1px solid var(--color-border);
       border-radius: var(--radius-md);
       box-shadow: var(--shadow-elevation-4);
     }
@@ -56,7 +56,7 @@
 
     :global(code) {
       background-color: var(--color-text);
-      color: var(--color-background);
+      color: var(--color-text-inverse);
       padding: var(--space-3xs) var(--space-2xs);
       border-radius: var(--radius-sm);
       font-family: "Courier New", monospace;
@@ -64,7 +64,7 @@
 
     :global(pre) {
       background-color: var(--color-text);
-      color: var(--color-background);
+      color: var(--color-text-inverse);
       padding: var(--space-s);
       border-radius: var(--radius-md);
       overflow-x: auto;
@@ -139,7 +139,7 @@
   th,
   td {
     padding: var(--space-2xs);
-    border: 1px solid var(--color-text);
+    border: 1px solid var(--color-border);
   }
 
   table {
@@ -150,7 +150,7 @@
 
   :not(pre) > code {
     background-color: var(--color-text);
-    color: var(--color-background);
+    color: var(--color-text-inverse);
     padding: var(--space-3xs) var(--space-2xs);
     border-radius: var(--radius-sm);
     margin: 0 var(--space-3xs);

--- a/src/pages/posts/_components/BlogPost/index.astro
+++ b/src/pages/posts/_components/BlogPost/index.astro
@@ -96,7 +96,7 @@ const { post, Content, headings } = Astro.props;
 
       .slide-badge {
         background-color: var(--color-link);
-        color: var(--color-background);
+        color: var(--color-text-inverse);
         padding: var(--space-3xs) var(--space-2xs);
         border-radius: var(--radius-sm);
         font-size: var(--step--1);
@@ -113,7 +113,7 @@ const { post, Content, headings } = Astro.props;
         height: auto;
         aspect-ratio: 720 / 378;
         object-fit: cover;
-        border: 8px solid var(--color-white);
+        border: 8px solid var(--color-surface);
         border-radius: var(--radius-md);
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
       }

--- a/src/pages/products/[slug].astro
+++ b/src/pages/products/[slug].astro
@@ -72,7 +72,7 @@ import CommonHead from "../../components/CommonHead.astro";
         align-items: center;
         gap: var(--space-2xs);
         padding: var(--space-2xs) var(--space-s);
-        background-color: var(--color-white);
+        background-color: var(--color-surface);
         height: fit-content;
         width: fit-content;
         border-radius: var(--radius-infinity);

--- a/src/pages/products/_components/ProductPost/index.astro
+++ b/src/pages/products/_components/ProductPost/index.astro
@@ -124,7 +124,7 @@ const { product, Content } = Astro.props;
       height: auto;
       aspect-ratio: 720 / 450;
       object-fit: cover;
-      border: 8px solid var(--color-white);
+      border: 8px solid var(--color-surface);
       border-radius: var(--radius-md);
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     }
@@ -142,16 +142,16 @@ const { product, Content } = Astro.props;
     align-items: center;
     gap: var(--space-2xs);
     padding: var(--space-xs) var(--space-s);
-    border: solid 1px var(--color-text);
+    border: solid 1px var(--color-border);
     border-radius: var(--radius-infinity);
     text-decoration: none;
     color: var(--color-text);
-    background-color: var(--color-white);
+    background-color: var(--color-surface);
     transition: background-color 0.2s;
 
     &:hover,
     &:focus {
-      background-color: var(--color-blue);
+      background-color: var(--color-accent);
     }
   }
 
@@ -164,7 +164,7 @@ const { product, Content } = Astro.props;
 
   .tech-badge {
     padding: var(--space-3xs) var(--space-xs);
-    background-color: var(--color-white);
+    background-color: var(--color-surface);
     border-radius: var(--radius-infinity);
     font-size: var(--step--1);
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,26 @@
 :root {
+  /* === Primitives ===
+     生の色値。ダーク/ライトに関係なく不変。
+     セマンティック層から参照することを基本とし、1〜2 箇所しか使わない例外的なケースのみ直接参照する。 */
   --color-white: #fff;
-  --color-background: #f0f0f0;
-  --color-text: #041b47;
-  --color-blue: #84c5ea;
-  --color-link: #023aa2;
+  --color-black: #000;
+  --color-pale: #f0f0f0;
+  --color-navy: #041b47;
+  --color-deep-navy: #04345c;
+  --color-sky: #84c5ea;
+  --color-blue: #023aa2;
+  --color-mint: #a8fff5;
+  --color-dark-cyan: #015483;
+
+  /* === Semantics ===
+     用途を表す名前。ライト/ダークでマッピング先のプリミティブを切り替える。 */
+  --color-background: var(--color-pale);
+  --color-surface: var(--color-white);
+  --color-text: var(--color-navy);
+  --color-text-inverse: var(--color-pale);
+  --color-border: var(--color-navy);
+  --color-link: var(--color-blue);
+  --color-accent: var(--color-sky);
 
   /* Fluid Type Scale (Utopia.fyi)
      Min viewport: 320px / Min font: 16px / Min scale: 1.2 (Minor Third)
@@ -97,11 +114,13 @@
 }
 
 :root.dark {
-  --color-white: #000;
-  --color-background: #04345c;
-  --color-text: #f0f0f0;
-  --color-blue: #015483;
-  --color-link: #A8FFF5;
+  --color-background: var(--color-deep-navy);
+  --color-surface: var(--color-black);
+  --color-text: var(--color-pale);
+  --color-text-inverse: var(--color-deep-navy);
+  --color-border: var(--color-pale);
+  --color-link: var(--color-mint);
+  --color-accent: var(--color-dark-cyan);
 }
 
 html {

--- a/src/ui/BlogPost/index.module.css
+++ b/src/ui/BlogPost/index.module.css
@@ -34,7 +34,7 @@
 }
 .slideBadge {
   background-color: var(--color-link);
-  color: var(--color-background);
+  color: var(--color-text-inverse);
   padding: var(--space-3xs) var(--space-2xs);
   border-radius: var(--radius-sm);
   font-size: var(--step--2);

--- a/src/ui/Breadcrumb/index.module.css
+++ b/src/ui/Breadcrumb/index.module.css
@@ -1,6 +1,6 @@
 .breadcrumbs {
   padding: var(--space-2xs) var(--space-s);
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
   height: fit-content;
   width: fit-content;
   border-radius: var(--radius-infinity);

--- a/src/ui/IconButton/index.module.css
+++ b/src/ui/IconButton/index.module.css
@@ -8,5 +8,5 @@
 }
 
 .button:hover {
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
 } 

--- a/src/ui/LinkButton/index.module.css
+++ b/src/ui/LinkButton/index.module.css
@@ -1,8 +1,8 @@
 .button {
   padding: var(--space-xs) var(--space-s);
-  border: solid 1px var(--color-text);
+  border: solid 1px var(--color-border);
   color: var(--color-text);
-  background-color: var(--color-white);
+  background-color: var(--color-surface);
   border-radius: var(--radius-infinity);
   width: fit-content;
   display: flex;
@@ -11,5 +11,5 @@
 }
 .button:hover,
 .button:focus {
-  background-color: var(--color-blue);
+  background-color: var(--color-accent);
 } 

--- a/src/ui/PageTitle/index.module.css
+++ b/src/ui/PageTitle/index.module.css
@@ -35,7 +35,7 @@
   position: absolute;
   width: 100%;
   height: 1px;
-  background-color: var(--color-text);
+  background-color: var(--color-border);
   bottom: 20%;
 }
 @media screen and (max-width: 1024px) /* sync with --bp-md */ {


### PR DESCRIPTION
## What

global.css のカラー変数を プリミティブ層 / セマンティック層 に分離し、用途を表す名前で参照できるようにした。

## Why

これまで --color-white がダークモードで #000 に切り替わるなど、名前と実態が乖離しており、新規にセマンティックカラーを追加する際の判断基準も曖昧だった。今回の整理により、今後セマンティックカラーを追加する際にどの層に置くか／どこから参照するかが明確になる。

副次的に、SlideControls でダークモード時に文字が見えなくなっていたバグも修正した（ハードコードされた暗背景の上で --color-white が #000 になっていたため）。

## 確認事項

- [x] ローカルで動作確認済み（ライト・ダーク両モード）
- [x] pnpm run check (Biome + stylelint) がパスする
- [x] pnpm build が成功する（19 ページ生成）
- [x] pnpm run test:unit がパスする