### PR TITLE
Fix text alignment in TopAboutMe component

### DIFF
--- a/src/pages/_components/TopAboutMe.astro
+++ b/src/pages/_components/TopAboutMe.astro
@@ -78,6 +78,7 @@ import { Button } from "../../ui/Button";
     .texts {
       display: flex;
       flex-direction: column;
+      align-items: flex-start;
       gap: var(--space-xl);
       max-width: var(--text-max-width);
       .title {


### PR DESCRIPTION
## 概要

TopAboutMe コンポーネントのテキストコンテナに `align-items: flex-start` を追加し、テキスト要素の左寄せ配置を明示的に指定しました。

## 変更内容

- `.texts` クラスに `align-items: flex-start` を追加
  - flexbox コンテナ内の子要素（title、description など）が左寄せで配置されるようになります
  - レイアウトの意図をより明確にします

## 確認事項

- [x] ローカルで動作確認済み
- [x] `pnpm run check` (Biome) がパスする
- [x] `pnpm run test:unit` がパスする

## スクリーンショット（UI変更がある場合）

N/A（レイアウト調整のため、視覚的な変化は最小限です）

https://claude.ai/code/session_01V1MG5UtZwGCB5EKse9HabH