### PR TITLE
デザインシステム: claude.ai/design 連携の構築と @kind 誤検出の修正

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -61,13 +61,31 @@ the sync uses a few adaptations beyond the converter defaults.
 - **Header/Footer/AnimationIcon are app-specific** (own nav routes, hardcoded social
   links, animation toggle) — useful as references but not generic building blocks.
 - **`@kind` comments in `src/styles/global.css` are load-bearing for claude.ai/design's
-  token classification** (`check_design_system`). The `--step-*` font tokens carry
-  `/* @kind font */` and the `--z-index-*` tokens carry `/* @kind other */`. The converter
-  passes CSS comments through to `_ds_bundle.css` verbatim (it doesn't process `@kind` —
-  the app-side checker reads them), so **never strip these trailing comments**; without
-  them the design panel re-flags 14 unclassified tokens. The `--text-max-width` clamp's
-  `+ 14.2857vw` fragment trips a false font-family warning in the panel — ignore it, the
-  token is correct.
+  token classification** (`check_design_system`). The converter passes CSS comments through
+  to `_ds_bundle.css` verbatim (it doesn't process `@kind` — the app-side checker reads
+  them), so **never strip these trailing comments**; without them the design panel re-flags
+  the tokens as unclassified.
+  - Current kinds: ALL 15 classified tokens carry `/* @kind other */` — the 9 `--step-*`,
+    `--text-max-width`, and the 5 `--z-index-*`.
+  - **Why not `@kind font`:** with `@kind font` (and with NO annotation), the panel parsed
+    each `clamp()` token's middle term (`min + Nvw`, e.g. `+ 0.1508vw`) as a font-family and
+    raised a recurring false **"Missing brand fonts"** warning listing those fragments. There
+    is no real missing font (BIZ UDPGothic loads via `styles.css`'s remote `@import`).
+  - **History 2026-06-27:** briefly tried `@kind font-size` (steps) / `@kind size`
+    (`--text-max-width`), then the owner chose to settle on `/* @kind other */` for all 10
+    fluid-type tokens. `other` is the proven-valid kind — the `--z-index-*` tokens always
+    used it and never trip the warning — so it reliably clears the false font warning.
+    Trade-off: these show under "other" in the panel, not a typography group. Stick with
+    `other` unless a future run confirms a real size-kind in the panel.
+  - **The checker also reads NEARBY comment TEXT, not just `@kind` (confirmed 2026-06-27):**
+    after switching all 10 tokens to `@kind other`, the 9 `--step-*` cleared but
+    `--text-max-width` STILL flagged — its preceding descriptive comment contained the literal
+    string **`font-size`** (and a `step-0` reference). The `--step-*` block's preceding comment
+    says `font` (e.g. "Min font: 16px") and was harmless, but the hyphenated `font-size` was
+    picked up as a font signal. Removing `font-size`/`step` wording from that comment cleared
+    it (owner-verified in the panel). **Keep `font`/`font-size`/`font-family` out of comments
+    sitting directly above a `clamp()` token** — the trailing `@kind other` alone isn't enough
+    if the preceding prose names a font property.
 - **`Button` is the generic action/link component.** `Button` (ui) renders `<a>` when given
   `href`, else `<button>` (discriminated union), with `startIcon`/`endIcon` (react-icons).
   The old `LinkButton` wrapper was REMOVED (it only forwarded `aria-label` + a fixed right

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,16 +25,16 @@
   /* Fluid Type Scale (Utopia.fyi)
      Min viewport: 320px / Min font: 16px / Min scale: 1.2 (Minor Third)
      Max viewport: 1440px / Max font: 20px / Max scale: 1.25 (Major Third) */
-  --step--2: clamp(0.6944rem, 0.6642rem + 0.1508vw, 0.8rem); /* @kind font */
-  --step--1: clamp(0.8333rem, 0.7857rem + 0.2381vw, 1rem); /* @kind font */
-  --step-0: clamp(1rem, 0.9286rem + 0.3571vw, 1.25rem); /* @kind font */
-  --step-1: clamp(1.2rem, 1.0964rem + 0.5179vw, 1.5625rem); /* @kind font */
-  --step-2: clamp(1.44rem, 1.2934rem + 0.733vw, 1.9531rem); /* @kind font */
-  --step-3: clamp(1.728rem, 1.5242rem + 1.0192vw, 2.4414rem); /* @kind font */
-  --step-4: clamp(2.0736rem, 1.7941rem + 1.3974vw, 3.0518rem); /* @kind font */
-  --step-5: clamp(2.4883rem, 2.1093rem + 1.8949vw, 3.8147rem); /* @kind font */
+  --step--2: clamp(0.6944rem, 0.6642rem + 0.1508vw, 0.8rem); /* @kind other */
+  --step--1: clamp(0.8333rem, 0.7857rem + 0.2381vw, 1rem); /* @kind other */
+  --step-0: clamp(1rem, 0.9286rem + 0.3571vw, 1.25rem); /* @kind other */
+  --step-1: clamp(1.2rem, 1.0964rem + 0.5179vw, 1.5625rem); /* @kind other */
+  --step-2: clamp(1.44rem, 1.2934rem + 0.733vw, 1.9531rem); /* @kind other */
+  --step-3: clamp(1.728rem, 1.5242rem + 1.0192vw, 2.4414rem); /* @kind other */
+  --step-4: clamp(2.0736rem, 1.7941rem + 1.3974vw, 3.0518rem); /* @kind other */
+  --step-5: clamp(2.4883rem, 2.1093rem + 1.8949vw, 3.8147rem); /* @kind other */
   /* step-6 はカスタム値（hero 専用、PageTitle SP の現状 32px を維持） */
-  --step-6: clamp(2rem, 0.8571rem + 5.7143vw, 6rem); /* @kind font */
+  --step-6: clamp(2rem, 0.8571rem + 5.7143vw, 6rem); /* @kind other */
 
   /* Line-height (用途別) */
   --leading-tight: 1;
@@ -74,9 +74,9 @@
   --bp-md-plus: 64.0625rem;
 
   /* Text measure (本文の読みやすい行長)
-     全角 40 文字を基準に body font-size (step-0 = 16→20px) に合わせて fluid 化
-     320px viewport: 40rem (= 16px × 40字)、1440px viewport: 50rem (= 20px × 40字) */
-  --text-max-width: clamp(40rem, 37.1429rem + 14.2857vw, 50rem);
+     全角 40 文字を基準に viewport 幅へ流動化
+     320px viewport: 40rem、1440px viewport: 50rem */
+  --text-max-width: clamp(40rem, 37.1429rem + 14.2857vw, 50rem); /* @kind other */
 
   /* Border Radius */
   --radius-none: 0px;


### PR DESCRIPTION
## 概要

claude.ai/design（Claude のデザインツール）へポートフォリオのコンポーネントを同期するためのデザインシステム基盤を構築し、あわせてデザインパネルのトークン分類まわりの問題を修正します。

## 主な変更

- **design-sync 基盤の追加**（`.design-sync/`）: claude.ai/design へ実コンポーネントを同期するための設定・型/エントリのバレル・規約・運用ノート。
- **`Button` コンポーネントの新設**（`src/ui/Button`）: `href` 指定時は `<a>`、それ以外は `<button>` を描画する判別ユニオン。`startIcon`/`endIcon` 対応。
- **`LinkButton` の削除**（`src/ui/LinkButton`）: 固定の右矢印と `aria-label` 転送のみで `Button` 以上の価値がないため撤去。「一覧/詳細」リンクは `Button` をインライン合成する形に置き換え。
- **Storybook 設定の修正**: SB10 に存在しない `@storybook/addon-viewport` を撤去（全ストーリーのプレビュー実行が壊れていた問題を解消）、ブランドフォント読み込み用に `preview-head.html` を追加。
- **`@kind` トークン注釈の修正**（`src/styles/global.css`）: clamp() の流動タイポグラフィ/幅トークン（`--step-*`, `--text-max-width`）が `check_design_system` に font-family として誤認され「Missing brand fonts」警告が出ていた問題を、全トークンを `@kind other` に統一し、近接コメントから `font-size` 表記を除去して解消。CSSの値・挙動は不変（コメントのみの変更）。

## 確認

- `astro check` / `astro build`: 成功
- Biome / stylelint: クリーン
- デザインパネル: 「Missing brand fonts」警告が解消（owner 確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)