### PR TITLE
feat(ui): 汎用 Tag コンポーネントを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ scrollToSlide({ target: 3 });
 - ユニットテストは `src/**/*.test.tsx` に配置し、jsdom 環境で実行
 - Storybook テストは vitest storybook 設定を使用
 - Header のテーマ永続化テストが一部失敗中（既存の問題でセッション設定とは無関係）
+- **意味のあるテスト項目がある場合のみ `index.test.tsx` を作成する**。渡した props がそのまま出力されるかを確認するだけの自明なテスト（検証価値のないテスト）は作らない
 
 ## セッション開始フック
 

--- a/src/ui/Tag/index.module.css
+++ b/src/ui/Tag/index.module.css
@@ -1,0 +1,23 @@
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-3xs) var(--space-s);
+  border-radius: var(--radius-infinity);
+  font-size: var(--step--1);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: var(--tracking-wide);
+  white-space: nowrap;
+  border: var(--border-width-md) solid transparent;
+}
+
+.primary {
+  background-color: var(--color-accent);
+  color: var(--color-text);
+}
+
+.secondary {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}

--- a/src/ui/Tag/index.stories.tsx
+++ b/src/ui/Tag/index.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Tag } from ".";
+
+const meta: Meta<typeof Tag> = {
+  title: "ui/Tag",
+  component: Tag,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "radio",
+      options: ["primary", "secondary"],
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "タグ／バッジを統一する汎用コンポーネントです。強弱は variant（primary / secondary）で表現します。",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tag>;
+
+export const Primary: Story = {
+  args: { variant: "primary", children: "primary" },
+};
+
+export const Secondary: Story = {
+  args: { variant: "secondary", children: "secondary" },
+};
+
+export const TechStack: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+      {["TypeScript", "React", "Astro", "CSS Modules", "Vitest"].map((t) => (
+        <Tag key={t} variant="secondary">
+          {t}
+        </Tag>
+      ))}
+    </div>
+  ),
+};

--- a/src/ui/Tag/index.tsx
+++ b/src/ui/Tag/index.tsx
@@ -1,0 +1,33 @@
+import type React from "react";
+import styles from "./index.module.css";
+
+export type TagVariant = "primary" | "secondary";
+
+export type TagProps = {
+  /** 表示ラベル。 */
+  children: React.ReactNode;
+  /** 見た目のスタイル。primary=塗り（強調）、secondary=枠線（控えめ）。 */
+  variant?: TagVariant;
+  /** 追加のクラス名。 */
+  className?: string;
+};
+
+/**
+ * タグ／バッジを統一する汎用コンポーネント。
+ * ピル形状（--radius-infinity）で、強弱は variant（primary / secondary）で表現する。
+ */
+export const Tag: React.FC<TagProps> = ({
+  children,
+  variant = "secondary",
+  className,
+}) => {
+  const classNames = [
+    styles.tag,
+    variant === "primary" ? styles.primary : styles.secondary,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return <span className={classNames}>{children}</span>;
+};


### PR DESCRIPTION
## 概要

Claude Design プロジェクト「yutteee Portfolio UI」の handoff（`tag-feature`）を基に、タグ／バッジを1つに統一する汎用 `Tag` コンポーネントを `src/ui/Tag/` に新規追加します。

対象デザイン: `templates/tag-preview/TagPreview.dc.html`

## 変更内容

- **`src/ui/Tag/`** を新規追加
  - `index.tsx`: `variant`（`primary` / `secondary`、既定は `secondary`）と `className` を受け取り `<span>` を描画
  - `index.module.css`: ピル形状（`--radius-infinity`）＋ セマンティックトークンのみ。light/dark 両テーマに自動追従
  - `index.stories.tsx`: Primary / Secondary / TechStack のストーリー
- **`CLAUDE.md`**: 自明な props 受け渡し確認だけのテストは作らない方針を追記

## バリアント

| variant | 用途 | 見た目 |
|---|---|---|
| `primary` | ステータス／強調 | `--color-accent` 塗り |
| `secondary`（既定） | 技術タグなど | サーフェス＋枠線 |

## スコープ

今回は**新規コンポーネントの追加のみ**。既存バッジ（`BlogPost` のスライドバッジ、`ProductPost` の技術タグ）の置き換えは対象外です。

## 検証

- `pnpm check`（Biome + stylelint）: エラーなし
- `pnpm astro check`（型）: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)