### PR TITLE
feat(ui): Tag コンポーネントを各所へ導入しスライドタグのバグを修正

### DIFF
--- a/src/pages/_components/TopArticles.astro
+++ b/src/pages/_components/TopArticles.astro
@@ -26,6 +26,7 @@ const allPosts = await getAllPosts();
             date={post.pubDate}
             alt={post.alt}
             isExternal={post.isExternal}
+            marp={post.marp}
           />
         ))
     }

--- a/src/pages/products/_components/ProductPost/index.astro
+++ b/src/pages/products/_components/ProductPost/index.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from "astro:content";
 import { FiLink, FiGithub } from "react-icons/fi";
 import { Button } from "../../../../ui/Button";
+import { Tag } from "../../../../ui/Tag";
 import "../../../posts/_components/BlogPost/content.css";
 
 interface Props {
@@ -62,7 +63,7 @@ const { product, Content } = Astro.props;
       product.data.tech && product.data.tech.length > 0 && (
         <div class="tech-stack">
           {product.data.tech.map((t: string) => (
-            <span class="tech-badge">{t}</span>
+            <Tag variant="secondary">{t}</Tag>
           ))}
         </div>
       )
@@ -141,12 +142,5 @@ const { product, Content } = Astro.props;
     gap: var(--space-2xs);
     flex-wrap: wrap;
     justify-content: center;
-  }
-
-  .tech-badge {
-    padding: var(--space-3xs) var(--space-xs);
-    background-color: var(--color-surface);
-    border-radius: var(--radius-infinity);
-    font-size: var(--step--1);
   }
 </style>

--- a/src/ui/BlogPost/index.module.css
+++ b/src/ui/BlogPost/index.module.css
@@ -32,14 +32,6 @@
   gap: var(--space-2xs);
   font-size: var(--step--1);
 }
-.slideBadge {
-  background-color: var(--color-link);
-  color: var(--color-text-inverse);
-  padding: var(--space-3xs) var(--space-2xs);
-  border-radius: var(--radius-sm);
-  font-size: var(--step--2);
-  font-weight: bold;
-}
 .title {
   font-size: var(--step-0);
   font-weight: 700;

--- a/src/ui/BlogPost/index.tsx
+++ b/src/ui/BlogPost/index.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import styles from "./index.module.css";
 import { FiExternalLink } from "react-icons/fi";
+import { Tag } from "../Tag";
 
 export type BlogPostProps = {
   title: string;
@@ -42,7 +43,7 @@ export const BlogPost: React.FC<BlogPostProps> = ({
         <div className={styles.texts}>
           <div className={styles.meta}>
             <div>{date}</div>
-            {marp && <span className={styles.slideBadge}>スライド</span>}
+            {marp && <Tag variant="primary">スライド</Tag>}
           </div>
           <div className={styles.title}>
             <span>{title}</span>


### PR DESCRIPTION
## 概要

汎用 `Tag` コンポーネントを、利用できる箇所へ導入しました。あわせて、トップページのブログ欄でスライドタグが表示されないバグを修正しています。

## 変更内容

### Tag コンポーネントの導入

- **プロダクト詳細ページ**: 技術スタックの独自バッジ（`.tech-badge`）を `Tag`（`secondary`）に置き換え。専用 CSS を削除。
- **ブログのスライドタグ**: `BlogPost` の「スライド」バッジ（`slideBadge`）を `Tag`（`primary`）に置き換え。専用 CSS を削除。

### バグ修正

- **トップページのブログ欄**: `TopArticles.astro` から `BlogPost` へ `marp` prop が渡されておらず、スライド記事でも「スライド」タグが表示されていませんでした。`marp={post.marp}` を渡して修正（記事一覧ページと挙動を揃えました）。

## 動作確認

- `pnpm check`（Biome + Stylelint）: パス
- `pnpm astro check`（型チェック）: 0 errors

## 影響範囲

- プロダクト詳細ページの技術スタック表示
- ブログカードのスライドタグ（トップページ・記事一覧）

🤖 Generated with [Claude Code](https://claude.com/claude-code)