### PR TITLE
feat(about): 自己紹介を共通化し経歴をタイムライン表示に変更

### DIFF
--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -1,0 +1,115 @@
+---
+import { Image } from "astro:assets";
+
+/**
+ * 自己紹介セクション。モニターの中に顔写真を置く PC モチーフと共通の紹介文を持つ。
+ * - default スロット: 紹介文に続く追加の段落
+ * - footer スロット: CTA ボタンなど、本文の後に置く要素
+ */
+interface Props {
+  /** 見出しタグ。トップでは h1、他ページでは h2 を指定する */
+  headingTag?: "h1" | "h2";
+}
+
+const { headingTag } = Astro.props;
+const Heading = headingTag ?? "h2";
+---
+
+<div class="about">
+  <div class="pc">
+    <div class="monitor">
+      <Image
+        src="/yutteee.png"
+        width="300"
+        height="187.5"
+        class="screen"
+        alt="顔写真：黒い服を着た、黒髪を分けている男性(中村優作)が座ってパソコンの画面を見ている。"
+      />
+    </div>
+    <div class="keyboard"></div>
+  </div>
+  <section class="texts">
+    <Heading class="title">中村 優作</Heading>
+    <div class="body">
+      <p>
+        都内でエンジニアをしています。フロントエンドとデザインが好きです。
+      </p>
+      <p>また、株式会社KANNONでデザインエンジニアとしても活動しています。</p>
+      <slot />
+    </div>
+    <slot name="footer" />
+  </section>
+</div>
+
+<style>
+  .about {
+    display: flex;
+    gap: var(--space-2xl);
+    justify-content: center;
+    align-items: center;
+
+    @media screen and (max-width: 1024px) /* sync with --bp-md */ {
+      flex-direction: column;
+    }
+
+    .pc {
+      width: 100%;
+      max-width: 300px;
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+      gap: var(--space-xl);
+      flex-shrink: 0;
+
+      .monitor {
+        width: 300px;
+        height: 187.5px;
+        background-color: var(--color-surface);
+        border-radius: var(--radius-xl);
+        border: 8px solid var(--color-surface);
+        position: relative;
+
+        .screen {
+          position: absolute;
+          top: 0;
+          left: 0;
+          background-color: var(--color-surface);
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          border-radius: var(--radius-md);
+        }
+      }
+
+      .keyboard {
+        width: 150px;
+        border-bottom: 30px solid var(--color-surface);
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+      }
+    }
+
+    .texts {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--space-xl);
+      max-width: var(--text-max-width);
+
+      .title {
+        font-size: var(--step-3);
+        font-weight: 900;
+      }
+
+      h1.title {
+        font-size: var(--step-5);
+      }
+
+      .body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2xs);
+      }
+    }
+  }
+</style>

--- a/src/pages/_components/TopAboutMe.astro
+++ b/src/pages/_components/TopAboutMe.astro
@@ -1,90 +1,16 @@
 ---
-import { Image } from "astro:assets";
 import { FiArrowRight } from "react-icons/fi";
+import AboutMe from "../../components/AboutMe.astro";
 import { Button } from "../../ui/Button";
 ---
 
-<div class="about">
-  <div class="pc">
-    <div class="monitor">
-      <Image
-        src="/yutteee.png"
-        width="300"
-        height="187.5"
-        id="screen0"
-        class="screen"
-        alt="顔写真：黒い服を着た、黒髪を分けている男性(中村優作)が座ってパソコンの画面を見ている。"
-      />
-    </div>
-    <div class="keyboard"></div>
-  </div>
-  <section class="texts">
-    <h1 class="title">中村 優作</h1>
-    <p>
-      都内でエンジニアをしています。フロントエンドとデザインが好きです。<br />
-      また、株式会社KANNONでデザインエンジニアとしても活動しています。
-    </p>
-    <Button href="/about/" aria-label="私について" endIcon={FiArrowRight}>
-      私について
-    </Button>
-  </section>
-</div>
-<style>
-  .about {
-    display: flex;
-    gap: var(--space-2xl);
-    justify-content: center;
-    align-items: center;
-
-    @media screen and (max-width: 1024px) /* sync with --bp-md */ {
-      flex-direction: column;
-    }
-
-    .pc {
-      width: 100%;
-      max-width: 300px;
-      display: flex;
-      align-items: center;
-      flex-direction: column;
-      gap: var(--space-xl);
-      .monitor {
-        width: 300px;
-        height: 187.5px;
-        background-color: var(--color-surface);
-        border-radius: var(--radius-xl);
-        border: 8px solid var(--color-surface);
-        position: relative;
-
-        .screen {
-          position: absolute;
-          top: 0;
-          left: 0;
-          background-color: var(--color-surface);
-          width: 100%;
-          height: 100%;
-          object-fit: cover;
-          border-radius: var(--radius-md);
-        }
-      }
-
-      .keyboard {
-        width: 150px;
-        border-bottom: 30px solid var(--color-surface);
-        border-left: 8px solid transparent;
-        border-right: 8px solid transparent;
-      }
-    }
-
-    .texts {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-xl);
-      max-width: var(--text-max-width);
-      .title {
-        font-size: var(--step-5);
-        font-weight: 900;
-      }
-    }
-  }
-</style>
+<AboutMe headingTag="h1">
+  <Button
+    slot="footer"
+    href="/about/"
+    aria-label="私について"
+    endIcon={FiArrowRight}
+  >
+    私について
+  </Button>
+</AboutMe>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,74 +1,29 @@
 ---
+import AboutMe from "../components/AboutMe.astro";
+import { histories } from "../data/history";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { PageTitle } from "../ui/PageTitle";
+import { Timeline } from "../ui/Timeline";
+
 const pageTitle = "私について";
 const pageDescription = "中村優作の自己紹介ページです。";
-import { histories } from "../data/history";
-import { PageTitle } from "../ui/PageTitle";
-import { Image } from "astro:assets";
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription}>
   <main class="container">
     <PageTitle title="私について" />
     <div class="wrapper">
-      <section class="section-2">
-        <h2 class="h2">中村優作</h2>
-        <div class="section-flex">
-          <div class="description">
-            <p>
-              都内でエンジニアをしています。フロントエンドとデザインが好きです。
-            </p>
-            <p>
-              また、株式会社KANNONでデザインエンジニアとしても活動しています。
-            </p>
-            <p>
-              誰にとっても使いやすいプロダクトを開発することがしたいです。そのために必要なことは全部やりたいというスタンスで開発しています。フロントエンドの開発を軸に、プロダクトの技術的な意思決定を行うことができるエンジニアを目指しています。
-            </p>
-            <p>お笑い、読書、ランニング、コストコが好きです。</p>
-          </div>
-          <div class="image-wrapper">
-            <Image
-              src="/yutteee.png"
-              width="400"
-              height="250"
-              id="screen0"
-              alt="顔写真：黒い服を着た、黒髪を分けている男性(中村優作)が座ってパソコンの画面を見ている。"
-              class="image"
-            />
-          </div>
-        </div>
+      <section class="section">
+        <AboutMe headingTag="h2">
+          <p>
+            誰にとっても使いやすいプロダクトを開発することがしたいです。そのために必要なことは全部やりたいというスタンスで開発しています。フロントエンドの開発を軸に、プロダクトの技術的な意思決定を行うことができるエンジニアを目指しています。
+          </p>
+          <p>お笑い、読書、ランニング、コストコが好きです。</p>
+        </AboutMe>
       </section>
-      <section class="section-2">
-        <h2 class="h2">経歴</h2>
-        <div class="histories">
-          {
-            histories.map((history, index) => (
-              <section id={`history-item${index}`}>
-                <div class="title-flex">
-                  <h3 class="h3">{history.title}</h3>
-                  <div>{history.period}</div>
-                </div>
-                <div class="section-flex">
-                  <div class="description">
-                    {history.description.map((desc) => (
-                      <p>{desc}</p>
-                    ))}
-                  </div>
-                  <div class="image-wrapper">
-                    <Image
-                      src={history.image}
-                      width="400"
-                      height="250"
-                      id={`screen${histories.length - index}`}
-                      alt={history.alt}
-                      class="image"
-                    />
-                  </div>
-                </div>
-              </section>
-            ))
-          }
-        </div>
+      <section class="section">
+        <h2 class="heading">経歴</h2>
+        <Timeline items={histories} />
       </section>
     </div>
   </main>
@@ -85,73 +40,21 @@ import { Image } from "astro:assets";
     .wrapper {
       display: flex;
       flex-direction: column;
+      gap: var(--space-3xl);
       max-width: 90rem;
       width: 100%;
-      align-items: center;
+      padding-top: var(--space-2xl);
       padding-bottom: var(--space-3xl);
     }
 
-    .section-2 {
+    .section {
       width: 100%;
     }
 
-    .title-flex {
-      margin-top: var(--space-xl);
-      display: flex;
-      flex-direction: row;
-      gap: var(--space-2xs);
-      align-items: end;
-    }
-
-    .description {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-2xs);
-      margin-top: var(--space-2xs);
-      width: 100%;
-      max-width: var(--text-max-width);
-    }
-    .h2 {
-      margin-top: var(--space-2xl);
+    .heading {
       font-size: var(--step-2);
       font-weight: 900;
-    }
-
-    .h3 {
-      font-size: var(--step-1);
-      font-weight: 900;
-    }
-
-    .section-flex {
-      display: flex;
-      gap: var(--space-l);
-      width: 100%;
-
-      @media screen and (max-width: 40rem) /* sync with --bp-sm */ {
-        flex-direction: column;
-        gap: var(--space-s);
-        align-items: center;
-      }
-    }
-
-    .image-wrapper {
-      flex: 1;
-      min-width: 0;
-      position: relative;
-      aspect-ratio: 8/5;
-
-      @media screen and (max-width: 40rem) /* sync with --bp-sm */ {
-        width: 100%;
-      }
-
-      .image {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        border-radius: var(--radius-md);
-        position: sticky;
-        top: 5rem;
-      }
+      margin-bottom: var(--space-l);
     }
   </style>
 </BaseLayout>

--- a/src/ui/Timeline/index.module.css
+++ b/src/ui/Timeline/index.module.css
@@ -1,0 +1,100 @@
+.timeline {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.item {
+  position: relative;
+  padding-left: var(--space-xl);
+  padding-bottom: var(--space-2xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-s);
+}
+
+.item:last-child {
+  padding-bottom: 0;
+}
+
+/* 項目同士をつなぐ縦のライン */
+.item::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--space-m) / 2);
+  width: var(--border-width-lg);
+  transform: translateX(-50%);
+  background-color: var(--color-border);
+}
+
+.item:last-child::before {
+  display: none;
+}
+
+/* マーカー: PC モチーフを応用したミニモニター（8/5 の角丸矩形） */
+.item::after {
+  content: "";
+  position: absolute;
+  top: var(--space-4xs);
+  left: 0;
+  width: var(--space-m);
+  aspect-ratio: 8 / 5;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-accent);
+  border: var(--border-width-lg) solid var(--color-border);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+}
+
+.period {
+  font-size: var(--step--1);
+  letter-spacing: var(--tracking-wide);
+}
+
+.title {
+  font-size: var(--step-1);
+  font-weight: 900;
+}
+
+.body {
+  display: flex;
+  gap: var(--space-l);
+  align-items: flex-start;
+  width: 100%;
+}
+
+@media screen and (max-width: 40rem) /* sync with --bp-sm */ {
+  .body {
+    flex-direction: column;
+    gap: var(--space-s);
+  }
+}
+
+.description {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  max-width: var(--text-max-width);
+}
+
+.imageWrapper {
+  flex: 1;
+  min-width: 0;
+  max-width: 25rem;
+  width: 100%;
+}
+
+.image {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 8/5;
+  object-fit: cover;
+  border-radius: var(--radius-md);
+}

--- a/src/ui/Timeline/index.stories.tsx
+++ b/src/ui/Timeline/index.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Timeline } from ".";
+
+const meta: Meta<typeof Timeline> = {
+  title: "ui/Timeline",
+  component: Timeline,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "経歴などの時系列情報を縦のタイムライン形式で表示する。マーカーは PC モチーフを応用したミニモニター型。",
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Timeline>;
+
+export const Default: Story = {
+  args: {
+    items: [
+      {
+        title: "◯◯大学入学",
+        period: "2021年4月〜2025年3月",
+        description: [
+          "1つ目の出来事の説明文が入ります。",
+          "2つ目の段落の説明文が入ります。",
+        ],
+        image: "https://placehold.jp/400x250.png",
+        alt: "ダミー画像",
+      },
+      {
+        title: "コンテスト優秀賞",
+        period: "2022年8月",
+        description: ["2つ目の出来事の説明文が入ります。"],
+        image: "https://placehold.jp/400x250.png",
+        alt: "ダミー画像",
+      },
+      {
+        title: "株式会社◯◯",
+        period: "2024年2月〜現在",
+        description: ["3つ目の出来事の説明文が入ります。"],
+        image: "https://placehold.jp/400x250.png",
+        alt: "ダミー画像",
+      },
+    ],
+  },
+};
+
+export const SingleItem: Story = {
+  args: {
+    items: [
+      {
+        title: "◯◯大学入学",
+        period: "2021年4月〜2025年3月",
+        description: ["出来事の説明文が入ります。"],
+        image: "https://placehold.jp/400x250.png",
+        alt: "ダミー画像",
+      },
+    ],
+  },
+};

--- a/src/ui/Timeline/index.test.tsx
+++ b/src/ui/Timeline/index.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+import { Timeline } from ".";
+
+const items = [
+  {
+    title: "出来事1",
+    period: "2021年4月",
+    description: ["説明1"],
+    image: "https://placehold.jp/400x250.png",
+    alt: "画像1の説明",
+  },
+  {
+    title: "出来事2",
+    period: "2022年8月",
+    description: ["説明2"],
+    image: "https://placehold.jp/400x250.png",
+    alt: "画像2の説明",
+  },
+];
+
+describe("Timeline", () => {
+  it("時系列リスト（ol/li）としてマークアップされる", () => {
+    render(<Timeline items={items} />);
+    const list = screen.getByRole("list");
+    expect(list.tagName).toBe("OL");
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("各項目のタイトルがレベル3の見出しになる", () => {
+    render(<Timeline items={items} />);
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    expect(headings.map((h) => h.textContent)).toEqual(["出来事1", "出来事2"]);
+  });
+
+  it("画像に代替テキストが設定される", () => {
+    render(<Timeline items={items} />);
+    expect(screen.getByAltText("画像1の説明")).toBeInTheDocument();
+    expect(screen.getByAltText("画像2の説明")).toBeInTheDocument();
+  });
+});

--- a/src/ui/Timeline/index.tsx
+++ b/src/ui/Timeline/index.tsx
@@ -1,0 +1,46 @@
+import type React from "react";
+import styles from "./index.module.css";
+
+export type TimelineItem = {
+  title: string;
+  period: string;
+  description: string[];
+  image: string;
+  alt: string;
+};
+
+export type TimelineProps = {
+  items: TimelineItem[];
+};
+
+export const Timeline: React.FC<TimelineProps> = ({ items }) => {
+  return (
+    <ol className={styles.timeline}>
+      {items.map((item) => (
+        <li key={item.title} className={styles.item}>
+          <div className={styles.header}>
+            <span className={styles.period}>{item.period}</span>
+            <h3 className={styles.title}>{item.title}</h3>
+          </div>
+          <div className={styles.body}>
+            <div className={styles.description}>
+              {item.description.map((desc) => (
+                <p key={desc}>{desc}</p>
+              ))}
+            </div>
+            <div className={styles.imageWrapper}>
+              <img
+                src={item.image}
+                alt={item.alt}
+                className={styles.image}
+                width={400}
+                height={250}
+                loading="lazy"
+              />
+            </div>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+};


### PR DESCRIPTION
## 概要

about ページをデザインシステムに沿ってリデザインしました。トップページとほぼ同じ内容だった自己紹介部分を共通コンポーネント化し、経歴セクションをタイムライン形式に変更します。

## 変更内容

- `src/components/AboutMe.astro` を新規作成。「モニターの中に顔写真を置く」PC モチーフの自己紹介をトップと about ページで共用する
  - `headingTag` prop で見出しレベルを切り替え（トップ: h1 / about: h2。h2 時は名前を `--step-3` に落とし、PageTitle の `--step-6` と競合させない）
  - default スロットで追加の段落、`footer` スロットで CTA ボタンを差し込む構成
  - `TopAboutMe.astro` は AboutMe を使う薄いラッパーに変更（トップの見た目は従来通り）
- `src/ui/Timeline` を新規作成。経歴を縦のタイムライン形式で表示する純粋 UI コンポーネント
  - マーカーは PC モチーフを応用したミニモニター型（8/5 の角丸矩形、アクセント色）
  - `ol/li` の時系列リストとしてマークアップし、DOM ロールのユニットテストと Storybook ストーリーを追加
  - 色・余白はセマンティックトークン参照のためダークモード自動対応
- `about.astro` を PageTitle → AboutMe → 経歴タイムラインの構成に再編し、スクリプトから参照されていなかった `screen*` の id を削除

## 確認事項

- [x] ローカルで動作確認済み（ビルド結果をブラウザで表示し、about のライト / ダーク / モバイルとトップページを目視確認）
- [x] `pnpm run check` (Biome) がパスする
- [x] `pnpm run test:unit` がパスする

※ `pnpm test:storybook` は実行環境に Playwright headless shell がなく実行不可でした（既存の環境制約。Chromatic / CI での確認を想定）

## スクリーンショット（UI変更がある場合）

| Before | After |
| --- | --- |
| 見出し+段落+画像の羅列（経歴は左右2カラム） | PC モチーフの自己紹介 + ミニモニター型マーカーのタイムライン |

手元環境のスクリーンショット（ライト / ダーク / モバイル）はセッション内で確認済みです。必要であればコメントに添付します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wW4AYPt3kDda4coVnvNYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015wW4AYPt3kDda4coVnvNYJ)_